### PR TITLE
feat: UiTweak `ShowShieldOnHPBar`

### DIFF
--- a/Tweaks/UiAdjustment/ShowShieldOnHPBar.cs
+++ b/Tweaks/UiAdjustment/ShowShieldOnHPBar.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using Dalamud.Game.Internal;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using SimpleTweaksPlugin.Helper;
+
+namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
+{
+    public unsafe class ShowShieldOnHPBar: UiAdjustments.SubTweak
+    {
+        public override string Name => "Show approx. Shield Value on HP Bar";
+
+        protected override string Author => "Chivalrik";
+
+        private AtkNineGridNode* shieldGrid;
+        private AtkNineGridNode* shieldGridOver;
+        public override void Enable()
+        {
+            PluginInterface.Framework.OnUpdateEvent += FrameworkOnUpdateSetup;
+            base.Enable();
+        }
+        
+        public override void Disable()
+        {
+            PluginInterface.Framework.OnUpdateEvent -= FrameworkOnUpdateSetup;
+            PluginInterface.Framework.OnUpdateEvent -= FrameworkOnUpdate;
+            if (shieldGrid != null)
+            {
+                shieldGrid->AtkResNode.Width = 0;
+            }
+            if (shieldGridOver != null)
+            {
+                shieldGridOver->AtkResNode.Width = 0;
+            }
+            base.Disable();
+        }
+
+        private void FrameworkOnUpdateSetup(Framework framework)
+        {           
+            try
+            {
+                var parameterWidget = Common.GetUnitBase("_ParameterWidget");
+                if (parameterWidget == null) return;
+                if (parameterWidget->UldManager.LoadedState != 3) return;
+                if (!parameterWidget->IsVisible) return;
+                var hpGaugeBar = ((AtkComponentNode*) parameterWidget->UldManager.NodeList[2]);
+                var hpNineGrid = (AtkNineGridNode*) hpGaugeBar->Component->UldManager.NodeList[3];
+                if (hpGaugeBar->Component->UldManager.NodeListCount == 7)
+                {
+                    // Create Nodes
+                    UiHelper.ExpandNodeList(hpGaugeBar, 2);
+
+                    shieldGrid = UiHelper.CloneNode(hpNineGrid);
+                    //shieldGrid->AtkResNode.NodeID = NodeSlideCastMarker;
+                    hpGaugeBar->Component->UldManager.NodeList[6]->PrevSiblingNode = (AtkResNode*) shieldGrid;
+                    shieldGrid->AtkResNode.NextSiblingNode = hpGaugeBar->Component->UldManager.NodeList[6];
+                    shieldGrid->AtkResNode.ParentNode = (AtkResNode*) hpGaugeBar;
+                    hpGaugeBar->Component->UldManager.NodeList[hpGaugeBar->Component->UldManager.NodeListCount++] =
+                        (AtkResNode*) shieldGrid;
+                    shieldGrid->AtkResNode.MultiplyRed = 255;
+                    shieldGrid->AtkResNode.MultiplyGreen = 255;
+                    shieldGrid->AtkResNode.MultiplyBlue = 0;
+                    shieldGrid->AtkResNode.AddRed = ushort.MaxValue;
+                    shieldGrid->AtkResNode.AddGreen = ushort.MaxValue;
+                    shieldGrid->AtkResNode.AddBlue = ushort.MaxValue;
+                    shieldGrid->PartID = 5;
+                    shieldGrid->AtkResNode.Width = 0;
+                    shieldGrid->AtkResNode.Flags_2 |= 1;
+
+                    shieldGridOver = UiHelper.CloneNode(hpNineGrid);
+                    shieldGrid->AtkResNode.PrevSiblingNode = (AtkResNode*) shieldGridOver;
+                    shieldGridOver->AtkResNode.NextSiblingNode = (AtkResNode*) shieldGrid;
+                    shieldGridOver->AtkResNode.ParentNode = (AtkResNode*) hpGaugeBar;
+                    hpGaugeBar->Component->UldManager.NodeList[hpGaugeBar->Component->UldManager.NodeListCount++] =
+                        (AtkResNode*) shieldGridOver;
+                    shieldGridOver->AtkResNode.MultiplyRed = 255;
+                    shieldGridOver->AtkResNode.MultiplyGreen = 255;
+                    shieldGridOver->AtkResNode.MultiplyBlue = 0;
+                    shieldGridOver->AtkResNode.AddRed = ushort.MaxValue;
+                    shieldGridOver->AtkResNode.AddGreen = ushort.MaxValue;
+                    shieldGridOver->AtkResNode.AddBlue = ushort.MaxValue;
+                    shieldGridOver->PartID = 5;
+                    shieldGridOver->AtkResNode.Width = 0;
+                    shieldGridOver->AtkResNode.Flags_2 |= 1;
+                }
+
+                shieldGrid = (AtkNineGridNode*) hpGaugeBar->Component->UldManager.NodeList[7];
+                shieldGridOver = (AtkNineGridNode*) hpGaugeBar->Component->UldManager.NodeList[8];
+                PluginInterface.Framework.OnUpdateEvent -= FrameworkOnUpdateSetup;
+                PluginInterface.Framework.OnUpdateEvent += FrameworkOnUpdate;
+            }
+            catch (Exception ex)
+            {
+                SimpleLog.Error(ex);
+            }
+        } 
+        
+        private void FrameworkOnUpdate(Framework framework)
+        {
+            try
+            {
+                var player = PluginInterface.ClientState.LocalPlayer;
+                // Shield Percentage as byte is at address 0x1997
+                var shieldRawPercentage = (*(byte*) (player.Address + 0x1997))/ 100f;
+                var playerHpPercentage = (float)player.CurrentHp / player.MaxHp;
+                var playerHpDownPercentage = 1f - playerHpPercentage;
+                var shieldOverPercentage = shieldRawPercentage - playerHpDownPercentage;
+                shieldOverPercentage = shieldOverPercentage < 0 ? 0 : shieldOverPercentage;
+                var shieldPercentage = shieldRawPercentage - shieldOverPercentage;
+
+                shieldGrid->AtkResNode.X = playerHpPercentage * 148;
+                shieldGrid->AtkResNode.Width = shieldPercentage > 0 ? (ushort)(shieldPercentage * 148 + 12 + 0.5f) : (ushort)0;
+                shieldGrid->AtkResNode.Flags_2 |= 1;
+                shieldGridOver->AtkResNode.Width = shieldOverPercentage > 0 ? (ushort)(shieldOverPercentage * 148 + 12 + 0.5f) : (ushort)0;
+            }
+            catch (Exception ex)
+            {
+                SimpleLog.Error(ex);
+            }
+        }
+    }
+}

--- a/Tweaks/UiAdjustment/ShowShieldOnHPBar.cs
+++ b/Tweaks/UiAdjustment/ShowShieldOnHPBar.cs
@@ -99,7 +99,8 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             try
             {
                 var player = PluginInterface.ClientState.LocalPlayer;
-                // Shield Percentage as byte is at address 0x1997
+                if (player == null) return;
+                // Shield Percentage as a byte is at address 0x1997
                 var shieldRawPercentage = (*(byte*) (player.Address + 0x1997))/ 100f;
                 var playerHpPercentage = (float)player.CurrentHp / player.MaxHp;
                 var playerHpDownPercentage = 1f - playerHpPercentage;


### PR DESCRIPTION
This tweaks shows a bar on the HP parameter bar which represents the approx. value of the
current shield.
Two NineGridNods are used, one for shield values over max HP and another for under.
![2021-05-05 16_43_51-FINAL FANTASY XIV](https://user-images.githubusercontent.com/77893938/117172651-4b1c1f80-adcc-11eb-9d8e-06b34bb70c14.png)
![2021-05-05 16_42_52-FINAL FANTASY XIV](https://user-images.githubusercontent.com/77893938/117172662-4e171000-adcc-11eb-9a71-b0be104489e9.png)

