### PR TITLE
Add `Hide Cross Hotbar` tweak

### DIFF
--- a/Tweaks/UiAdjustment/HideCrossHotbar.cs
+++ b/Tweaks/UiAdjustment/HideCrossHotbar.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Dalamud.Game.ClientState;
+using Dalamud.Game;
+using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Plugin;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using SimpleTweaksPlugin.TweakSystem;
+
+#if DEBUG
+using SimpleTweaksPlugin.Debugging;
+#endif
+
+namespace SimpleTweaksPlugin.Tweaks.UiAdjustment {
+    public unsafe class HideCrossHotbar : UiAdjustments.SubTweak {
+        public override string Name => "Hide Cross Hotbar";
+        public override string Description => "Allow hiding the cross hotbar while not in combat or dungeons.";
+        protected override string Author => "Chalkos";
+        
+        public class Configs : TweakConfig {
+
+            [TweakConfigOption("Show In Duty", 1)]
+            public bool ShowInDuty;
+
+            [TweakConfigOption("Show In Combat", 2)]
+            public bool ShowInCombat;
+
+        }
+
+        public Configs Config { get; private set; }
+        public override bool UseAutoConfig => true;
+        
+        public override void Enable() {
+            Config = LoadConfig<Configs>() ?? new Configs();
+            Service.Framework.Update += FrameworkUpdate;
+            base.Enable();
+        }
+        
+        private void FrameworkUpdate(Framework framework) {
+            try {
+                Update();
+            } catch {
+                // 
+            }
+            
+        }
+
+        private void Update(bool reset = false) {
+            var stage = AtkStage.GetSingleton();
+            var loadedUnitsList = &stage->RaptureAtkUnitManager->AtkUnitManager.AllLoadedUnitsList;
+            var addonList = &loadedUnitsList->AtkUnitEntries;
+            #if DEBUG
+            PerformanceMonitor.Begin();
+            #endif
+            for (var i = 0; i < loadedUnitsList->Count; i++) {
+                var addon = addonList[i];
+                var name = Marshal.PtrToStringAnsi(new IntPtr(addon->Name));
+                
+                if (name != null && name == "_ActionCross") {
+                    if (reset || Config.ShowInDuty && Service.Condition[ConditionFlag.BoundByDuty]) {
+                        if (addon->UldManager.NodeListCount == 0) addon->UldManager.UpdateDrawNodeList();
+                    } else if (Config.ShowInCombat && Service.Condition[ConditionFlag.InCombat]) {
+                        if (addon->UldManager.NodeListCount == 0) addon->UldManager.UpdateDrawNodeList();
+                    } else {
+                        addon->UldManager.NodeListCount = 0;
+                    }
+                }
+
+            }
+            #if DEBUG
+            PerformanceMonitor.End();
+            #endif
+        }
+
+        public override void Disable() {
+            Service.Framework.Update -= FrameworkUpdate;
+            try {
+                Update(true);
+            } catch {
+                //
+            }
+            SaveConfig(Config);
+            base.Disable();
+        }
+    }
+}


### PR DESCRIPTION
It's the same as `HideJobGauge` but manipulating the Cross Hotbar instead.

This was requested at https://github.com/goatcorp/suggestions/issues/602
the author said it would be nice to add as a tweak and it seemed easy enough to do (and it was)