### PR TITLE
Add Extra Estate Teleportation tweak

### DIFF
--- a/SimpleTweaksPlugin.cs
+++ b/SimpleTweaksPlugin.cs
@@ -31,6 +31,7 @@ using FFXIVClientInterface;
 using Newtonsoft.Json.Linq;
 using SimpleTweaksPlugin.Helper;
 using SimpleTweaksPlugin.TweakSystem;
+using XivCommon;
 #if DEBUG
 using System.Runtime.CompilerServices;
 using SimpleTweaksPlugin.Debugging;
@@ -46,6 +47,7 @@ namespace SimpleTweaksPlugin {
         public List<BaseTweak> Tweaks = new List<BaseTweak>();
 
         public IconManager IconManager { get; private set; }
+        public XivCommonBase XivCommon { get; private set; }
         
 
         private bool drawConfigWindow = false;
@@ -102,6 +104,7 @@ namespace SimpleTweaksPlugin {
                 hook.Dispose();
             }
             Common.HookList.Clear();
+            this.XivCommon.Dispose();
         }
 
         public int UpdateFrom = -1;
@@ -122,6 +125,7 @@ namespace SimpleTweaksPlugin {
             this.PluginConfig.Init(this, pluginInterface);
             
             IconManager = new IconManager(pluginInterface);
+            this.XivCommon = new XivCommonBase(Hooks.ContextMenu);
             
             UiHelper.Setup(Service.SigScanner);
             #if DEBUG

--- a/SimpleTweaksPlugin.csproj
+++ b/SimpleTweaksPlugin.csproj
@@ -12,6 +12,7 @@
         <AppendPlatformToOutputPath>false</AppendPlatformToOutputPath>
         <DebugSymbols>true</DebugSymbols>
         <DebugType>full</DebugType>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
     <PropertyGroup Label="Feature">
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -41,6 +42,7 @@
       <PackageReference Include="System.Numerics.Vectors" Version="4.1.3.0" />
       <PackageReference Include="DalamudPackager" Version="2.1.2" />
       <PackageReference Include="ILRepack" Version="2.1.0-beta1" GeneratePathProperty="true" />
+      <PackageReference Include="XivCommon" Version="3.1.0" />
     </ItemGroup>
     <Target Name="ILRepack" AfterTargets="PostBuildEvent">
         <ItemGroup>

--- a/Tweaks/UiAdjustment/ExtraEstateTeleportation.cs
+++ b/Tweaks/UiAdjustment/ExtraEstateTeleportation.cs
@@ -1,0 +1,103 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Dalamud.Logging;
+using ImGuiNET;
+using SimpleTweaksPlugin.TweakSystem;
+using XivCommon.Functions.ContextMenu;
+using XivCommon.Functions.FriendList;
+
+namespace SimpleTweaksPlugin.Tweaks.UiAdjustment {
+    internal class ExtraEstateTeleportation : UiAdjustments.SubTweak {
+        private static class Signatures {
+            internal const string ShowEstateTeleportation = "E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 45 33 F6 48 8B CF 44 89 B3 ?? ?? ?? ?? E8";
+        }
+
+        public override string Name => "Extra Estate Teleportation";
+        public override string Description => "Add the Estate Teleportation option to more locations.";
+        protected override string Author => "Anna";
+
+        private Configs Config { get; set; } = null!;
+
+        private delegate IntPtr ShowEstateTeleportationDelegate(IntPtr friendListAgent, ulong contentId);
+
+        private ShowEstateTeleportationDelegate? ShowEstateTeleportation { get; set; }
+
+        public class Configs : TweakConfig {
+            public bool PartyMemberList = true;
+            public bool PartyList;
+        }
+
+        protected override DrawConfigDelegate DrawConfigTree => (ref bool hasChanged) => {
+            hasChanged |= ImGui.Checkbox("Party Member List (Social window)", ref this.Config.PartyMemberList);
+            hasChanged |= ImGui.Checkbox("Party List", ref this.Config.PartyList);
+        };
+
+        public override void Enable() {
+            if (this.ShowEstateTeleportation == null && Service.SigScanner.TryScanText(Signatures.ShowEstateTeleportation, out var ptr)) {
+                this.ShowEstateTeleportation = Marshal.GetDelegateForFunctionPointer<ShowEstateTeleportationDelegate>(ptr);
+            }
+
+            this.Config = this.LoadConfig<Configs>() ?? new Configs();
+            this.Plugin.XivCommon.Functions.ContextMenu.OpenContextMenu += this.OnContextMenu;
+            base.Enable();
+        }
+
+        public override void Disable() {
+            this.Plugin.XivCommon.Functions.ContextMenu.OpenContextMenu -= this.OnContextMenu;
+            this.SaveConfig(this.Config);
+            base.Disable();
+        }
+
+        private void OnContextMenu(ContextMenuOpenArgs args) {
+            if (this.ShowEstateTeleportation == null || args.ParentAddonName is not ("PartyMemberList" or "_PartyList")) {
+                return;
+            }
+
+            switch (args.ParentAddonName) {
+                case "PartyMemberList" when !this.Config.PartyMemberList:
+                case "_PartyList" when !this.Config.PartyList:
+                    return;
+            }
+
+            var friends = this.Plugin.XivCommon.Functions.FriendList.List
+                .Where(friend => (friend.ContentId & 0xFFFFFFFF) == args.ContentIdLower)
+                .ToArray();
+
+            FriendListEntry? friend = null;
+            if (friends.Length == 1) {
+                friend = friends[0];
+            } else {
+                var matched = friends.Where(friend => friend.Name == args.Text).ToArray();
+                if (matched.Length > 0) {
+                    friend = matched[0];
+                }
+            }
+
+            if (friend == null) {
+                return;
+            }
+
+            var index = args.Items
+                .FindLastIndex(item => item is NativeContextMenuItem { InternalAction: 0x01 or 0x4E or 0x11 });
+
+            if (index == -1) {
+                index = args.Items.Count - 1;
+            }
+
+            index += 1;
+
+            args.Items.Insert(index, new NormalContextMenuItem("Estate Teleportation", _ => {
+                if (this.ShowEstateTeleportation == null) {
+                    return;
+                }
+
+                var friendListAgent = this.Plugin.XivCommon.Functions.GetAgentByInternalId(54);
+                if (friendListAgent != IntPtr.Zero) {
+                    this.ShowEstateTeleportation(friendListAgent, friend.Value.ContentId);
+                }
+            }));
+        }
+    }
+}


### PR DESCRIPTION
Adds a context menu item to the Party Member List (Social window) and/or the Party List that allows opening the Estate Teleportation window for friends.