### PR TITLE
[`HideJobGauge`]  : Option to show gauge while character weapon is drawn

### DIFF
--- a/Tweaks/UiAdjustment/HideJobGauge.cs
+++ b/Tweaks/UiAdjustment/HideJobGauge.cs
@@ -3,7 +3,9 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Dalamud.Game;
 using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Game.ClientState.Objects.Enums;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using SimpleTweaksPlugin;
 using SimpleTweaksPlugin.TweakSystem;
 
 #if DEBUG
@@ -26,6 +28,9 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment {
             public bool ShouldShowCombatBuffer() => ShowInCombat;
             [TweakConfigOption("Out of Combat Time (Seconds)", 3, EditorSize = 100, IntMin = 0, IntMax = 300, ConditionalDisplay = true)]
             public int CombatBuffer;
+
+            [TweakConfigOption("Show While Weapon Is Drawn", 4)]
+            public bool ShowWhileWeaponDrawn;
         }
 
         public Configs Config { get; private set; }
@@ -66,6 +71,8 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment {
                         outOfCombatTimer.Restart();
                         if (addon->UldManager.NodeListCount == 0) addon->UldManager.UpdateDrawNodeList();
                     } else if (Config.ShowInCombat && outOfCombatTimer.ElapsedMilliseconds < Config.CombatBuffer * 1000) {
+                        if (addon->UldManager.NodeListCount == 0) addon->UldManager.UpdateDrawNodeList();
+                    } else if (Config.ShowWhileWeaponDrawn && Service.ClientState.LocalPlayer != null && Service.ClientState.LocalPlayer.StatusFlags.HasFlag(StatusFlags.WeaponOut)) {
                         if (addon->UldManager.NodeListCount == 0) addon->UldManager.UpdateDrawNodeList();
                     } else {
                         addon->UldManager.NodeListCount = 0;


### PR DESCRIPTION
Inspired by an option in the delvui plugin, and thanks to the help of Eternita, I added the option to show the Job Gauge if the player character has their weapon drawn.

![weapondrawn](https://user-images.githubusercontent.com/7963736/143624841-debfc3f2-109d-4986-9d62-a9e7aa52c270.gif)


