### PR TITLE
Option to show delta in extended desynthesis window

### DIFF
--- a/Tweaks/UiAdjustment/ExtendedDesynthesisWindow.cs
+++ b/Tweaks/UiAdjustment/ExtendedDesynthesisWindow.cs
@@ -26,6 +26,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment {
         public class Configs : TweakConfig {
             public bool BlockClickOnGearset;
             public bool YellowForSkillGain = true;
+            public bool Delta;
         }
 
         public Configs Config { get; private set; }
@@ -33,6 +34,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment {
         protected override DrawConfigDelegate DrawConfigTree => (ref bool _) => {
             ImGui.Checkbox(LocString("BlockClickOnGearset", "Block clicking on gearset items."), ref Config.BlockClickOnGearset);
             ImGui.Checkbox(LocString("YellowForSkillGain", "Highlight potential skill gains (Yellow)"), ref Config.YellowForSkillGain);
+            ImGui.Checkbox(LocString("DesynthesisDelta", "Show desynthesis delta"), ref Config.Delta);
         };
 
         public override string Name => "Extended Desynthesis Window";
@@ -137,7 +139,13 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment {
                 }
                 
                 skillTextNode->TextColor = c;
-                skillTextNode->SetText($"{desynthLevel:F0}/{itemData.LevelItem.Row}");
+
+                if (Config.Delta) {
+                    var desynthDelta = itemData.LevelItem.Row - desynthLevel;
+                    skillTextNode->SetText($"{itemData.LevelItem.Row} ({desynthDelta:+#;-#})");
+                } else {
+                    skillTextNode->SetText($"{desynthLevel:F0}/{itemData.LevelItem.Row}");
+                }
 
                 var itemIdWithHQ = item->ItemId;
                 if ((item->Flags & ItemFlags.HQ) > 0) itemIdWithHQ += 1000000;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53450329/153483183-0dd7f444-d2e2-49ba-bacd-3a25a48cc1e1.png)
![image](https://user-images.githubusercontent.com/53450329/153483271-88aa6fb9-fd0b-4926-af71-d0de72aa3166.png)
Instead of showing your desynthesis skill, it'll show the difference between your skill and the item's desynthesis level, much like the option for the "Show Desynthesis Skill" tooltip tweak.

This is helpful for determining at a glance which items above your skill level to desynthesize first.