### PR TITLE
New Tweak: `Action Press Mirroring`

### DIFF
--- a/Tweaks/UiAdjustment/ActionPressMirroring.cs
+++ b/Tweaks/UiAdjustment/ActionPressMirroring.cs
@@ -1,0 +1,163 @@
+﻿using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.System.Framework;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using SimpleTweaksPlugin.Utility;
+using System;
+using System.Runtime.InteropServices;
+
+namespace SimpleTweaksPlugin.Tweaks.UiAdjustment;
+
+public unsafe class ActionPressMirroring : UiAdjustments.SubTweak
+{
+
+    private delegate void PulseActionBarSlot(AddonActionBarBase* addonActionBarBase, int slotIndex);
+
+    private HookWrapper<PulseActionBarSlot> pulseActionBarSlotHook;
+
+    private static string PulseActionBarSlotSig = "85 d2 78 ?? 48 89 5c 24 ?? 57 48 83 ec ?? 48 63 da 48 8b f9 48 8b 89 ?? ?? ?? ?? ba";
+
+    private ActionManager* actionManager;
+
+    private bool tweakIsPulsing = false;
+
+    public override string Name => "Duplicate Action Presses Between Hotbars";
+    public override string Description => "Will show the action press pulse on all hotbar slots with the same ability when you use it.";
+    protected override string Author => "BoredDan";
+
+    private static readonly string[] allActionBars = {
+        "_ActionBar",
+        "_ActionBar01",
+        "_ActionBar02",
+        "_ActionBar03",
+        "_ActionBar04",
+        "_ActionBar05",
+        "_ActionBar06",
+        "_ActionBar07",
+        "_ActionBar08",
+        "_ActionBar09",
+        "_ActionCross",
+        "_ActionDoubleCrossL",
+        "_ActionDoubleCrossR",
+        "_ActionEx",
+    };
+
+    public override void Enable()
+    {
+        pulseActionBarSlotHook ??= Common.Hook<PulseActionBarSlot>(PulseActionBarSlotSig, PulseActionBarSlotDetour);
+        pulseActionBarSlotHook?.Enable();
+        actionManager = ActionManager.Instance();
+        base.Enable();
+    }
+
+    private static AddonActionBarBase* GetActionBarAddon(string actionBar)
+    {
+        return (AddonActionBarBase*)Service.GameGui.GetAddonByName(actionBar, 1);
+    }
+
+    private void PulseActionBarSlotDetour(AddonActionBarBase* ab, int slotIndex)
+    {
+        if (tweakIsPulsing) goto PulseSlot;
+
+        var hotbarModule = Framework.Instance()->GetUiModule()->GetRaptureHotbarModule();
+        var name = Marshal.PtrToStringUTF8(new IntPtr(ab->AtkUnitBase.Name));
+        if (name == null) goto PulseSlot;
+        var hotbar = hotbarModule->HotBar[ab->RaptureHotbarId];
+        if (hotbar == null) goto PulseSlot;
+        var numSlots = ab->SlotCount;
+        if (numSlots <= slotIndex) goto PulseSlot;
+
+        tweakIsPulsing = true;
+
+        var slot = hotbar->Slot[slotIndex];
+        var commandType = slot->CommandType;
+        var commandId = slot->CommandType == HotbarSlotType.Action ? actionManager->GetAdjustedActionId(slot->CommandId) : slot->CommandId;
+
+        foreach (var actionBar in allActionBars)
+        {
+            var currentActionBar = (AddonActionBarBase*)Service.GameGui.GetAddonByName(actionBar, 1);
+            if (currentActionBar != null)
+            {
+                var isCross = actionBar.StartsWith("_ActionCross");
+                var crossBar = isCross ? (AddonActionCross*)currentActionBar : null;
+                var crossExpandedHoldControls = isCross ? crossBar->ExpandedHoldControls : 0;
+                var isExpandedCross = crossExpandedHoldControls > 0;
+
+                var isDoubleCross = actionBar.StartsWith("_ActionDoubleCross");
+                var doubleCrossBar = isDoubleCross ? (AddonActionDoubleCrossBase*)currentActionBar : null;
+
+                numSlots = currentActionBar->SlotCount;
+
+                int currentHotbarId = currentActionBar->RaptureHotbarId;
+                if (isExpandedCross)
+                {
+                    // crossExpandedHoldControls value  1-16 = left/right sides of cross bars 1-8 (IDs 10-17)
+                    currentHotbarId = (crossExpandedHoldControls < 17) ? (((crossExpandedHoldControls - 1) >> 1) + 10) :
+                    //                                  17-20 = "Cycle" options (uses bar before/after main active bar)
+                        (currentActionBar->RaptureHotbarId + (crossExpandedHoldControls < 19 ? 1 : -1) - 2) % 8 + 10;
+                }
+                else if (isDoubleCross)
+                {
+                    currentHotbarId = doubleCrossBar->BarTarget;
+                }
+
+                var currentHotbar = hotbarModule->HotBar[currentHotbarId];
+
+                if (currentHotbar != null)
+                {
+                    var offset = 0;
+                    var from = 0;
+                    var to = numSlots;
+
+                    if(isExpandedCross)
+                    {
+                        var exUseLeftSide = crossExpandedHoldControls & 1;
+
+                        //expanded cross hotbar uses middle 8 slots with left 4 and right 4 not visible
+                        offset = (exUseLeftSide != 0 ? -4 : 4);
+                        from = 4;
+                        to -= 4;
+                    }
+                    else if(isDoubleCross && doubleCrossBar->UseLeftSide == 0)
+                    {
+                        offset = 8;
+                    }
+
+                    for (int i = from; i < to; i++)
+                    {
+                        slot = currentHotbar->Slot[i + offset];
+                        var currentCommandType = slot->CommandType;
+                        var currentCommandId = slot->CommandType == HotbarSlotType.Action ? actionManager->GetAdjustedActionId(slot->CommandId) : slot->CommandId;
+                        if (currentCommandType == commandType && currentCommandId == commandId)
+                        {
+                            currentActionBar->PulseActionBarSlot(i);
+                        }
+                    }
+                }
+            }
+        }
+
+        tweakIsPulsing = false;
+
+        return;
+
+        PulseSlot:
+
+        pulseActionBarSlotHook.Original(ab, slotIndex);
+        return;
+
+    }
+
+    public override void Disable()
+    {
+        pulseActionBarSlotHook?.Disable();
+        base.Disable();
+    }
+
+    public override void Dispose()
+    {
+        pulseActionBarSlotHook?.Dispose();
+        base.Dispose();
+    }
+}
+

--- a/Tweaks/UiAdjustment/ActionPressMirroring.cs
+++ b/Tweaks/UiAdjustment/ActionPressMirroring.cs
@@ -62,10 +62,6 @@ public unsafe class ActionPressMirroring : UiAdjustments.SubTweak
         var hotbarModule = Framework.Instance()->GetUiModule()->GetRaptureHotbarModule();
         var name = Marshal.PtrToStringUTF8(new IntPtr(ab->AtkUnitBase.Name));
         if (name == null) goto PulseSlot;
-        if(name.StartsWith("_ActionBarEx"))
-        {
-            SimpleLog.Log(ab->RaptureHotbarId);
-        }
         var hotbar = hotbarModule->HotBar[ab->RaptureHotbarId];
         if (hotbar == null) goto PulseSlot;
         var numSlots = ab->SlotCount;

--- a/Tweaks/UiAdjustment/ActionPressMirroring.cs
+++ b/Tweaks/UiAdjustment/ActionPressMirroring.cs
@@ -39,7 +39,7 @@ public unsafe class ActionPressMirroring : UiAdjustments.SubTweak
         "_ActionCross",
         "_ActionDoubleCrossL",
         "_ActionDoubleCrossR",
-        "_ActionEx",
+        "_ActionBarEx",
     };
 
     public override void Enable()
@@ -62,6 +62,10 @@ public unsafe class ActionPressMirroring : UiAdjustments.SubTweak
         var hotbarModule = Framework.Instance()->GetUiModule()->GetRaptureHotbarModule();
         var name = Marshal.PtrToStringUTF8(new IntPtr(ab->AtkUnitBase.Name));
         if (name == null) goto PulseSlot;
+        if(name.StartsWith("_ActionBarEx"))
+        {
+            SimpleLog.Log(ab->RaptureHotbarId);
+        }
         var hotbar = hotbarModule->HotBar[ab->RaptureHotbarId];
         if (hotbar == null) goto PulseSlot;
         var numSlots = ab->SlotCount;


### PR DESCRIPTION
Added a new tweak to duplicate the action press pulse that happens when you press an ability onto any other hotbar slot with the same ability. Currently only works for pulse from regular hotbars and does not mirror the pulse when you click or the pulse from cross hotbar. It does however mirror pulses from regular hotbars onto the cross, expanded cross, and double cross hotbars.

This functionality has been requested multiple times by people that use the `Control Hint Mirroring`. I've put it into a separate tweak however so people can use it without `Control Hint Mirroring` if they'd like.