### PR TITLE
Optionally color the Tooltip Desynthesis delta/level similar to the ExtendedDesynthesisWindow

### DIFF
--- a/Tweaks/Tooltips/DesynthesisSkill.cs
+++ b/Tweaks/Tooltips/DesynthesisSkill.cs
@@ -5,6 +5,7 @@ using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using ImGuiNET;
 using Lumina.Excel;
+using Lumina.Excel.GeneratedSheets;
 using SimpleTweaksPlugin.Sheets;
 using SimpleTweaksPlugin.TweakSystem;
 using static SimpleTweaksPlugin.Tweaks.TooltipTweaks.ItemTooltipField;
@@ -19,8 +20,9 @@ public class DesynthesisSkill : TooltipTweaks.SubTweak {
 
     public class Configs : TweakConfig {
         public bool Delta;
+        public bool Colour;
     }
-        
+
     public Configs Config { get; private set; }
 
     private ExcelSheet<ExtendedItem> itemSheet;
@@ -37,6 +39,20 @@ public class DesynthesisSkill : TooltipTweaks.SubTweak {
         base.Disable();
     }
 
+    private const ushort Red = 14;// 511;
+    private const ushort Yellow = 514;
+    private const ushort Green = 45;//42;
+    private uint maxDesynthLevel = 590;
+
+    public override void Setup()
+    {
+        foreach (var i in Service.Data.Excel.GetSheet<Item>())
+        {
+            if (i.Desynth > 0 && i.LevelItem.Row > maxDesynthLevel) maxDesynthLevel = i.LevelItem.Row;
+        }
+        base.Setup();
+    }
+
     public override unsafe void OnGenerateItemTooltip(NumberArrayData* numberArrayData, StringArrayData* stringArrayData) {
         var id = Service.GameGui.HoveredItem;
         if (id < 2000000) {
@@ -50,14 +66,25 @@ public class DesynthesisSkill : TooltipTweaks.SubTweak {
 
                 var seStr = GetTooltipString(stringArrayData, useDescription ? ItemDescription : ExtractableProjectableDesynthesizable);
 
+                ushort c = Red;
+                if (desynthLevel >= maxDesynthLevel || desynthLevel >= item.LevelItem.Row + 50) {
+                    c = Green;
+                } else if (desynthLevel > item.LevelItem.Row) {
+                    c = Yellow;
+                }
+
                 if (seStr != null && seStr.Payloads.Count > 0) {
                     if (seStr.Payloads.Last() is TextPayload textPayload && textPayload.Text != null) {
+                        textPayload.Text = textPayload.Text.Replace($"{item.LevelItem.Row},00", $"{item.LevelItem.Row} ");
+                        textPayload.Text = textPayload.Text.Replace($"{item.LevelItem.Row}.00", $"{item.LevelItem.Row} ");
                         if (Config.Delta) {
-                            textPayload.Text = textPayload.Text.Replace($"{item.LevelItem.Row},00", $"{item.LevelItem.Row} ({desynthDelta:+#;-#})");
-                            textPayload.Text = textPayload.Text.Replace($"{item.LevelItem.Row}.00", $"{item.LevelItem.Row} ({desynthDelta:+#;-#})");
+                            if (Config.Colour) seStr.Payloads.Add(new UIForegroundPayload(c));
+                            seStr.Payloads.Add(new TextPayload($"({desynthDelta:+#;-#})"));
+                            if (Config.Colour) seStr.Payloads.Add(new UIForegroundPayload(0));
                         } else {
-                            textPayload.Text = textPayload.Text.Replace($"{item.LevelItem.Row},00", $"{item.LevelItem.Row} ({MathF.Floor(desynthLevel):F0})");
-                            textPayload.Text = textPayload.Text.Replace($"{item.LevelItem.Row}.00", $"{item.LevelItem.Row} ({MathF.Floor(desynthLevel):F0})");
+                            if (Config.Colour) seStr.Payloads.Add(new UIForegroundPayload(c));
+                            seStr.Payloads.Add(new TextPayload($"({MathF.Floor(desynthLevel):F0})"));
+                            if (Config.Colour) seStr.Payloads.Add(new UIForegroundPayload(0));
                         }
                         SetTooltipString(stringArrayData, useDescription ? ItemDescription : ExtractableProjectableDesynthesizable, seStr);
                     }
@@ -67,6 +94,7 @@ public class DesynthesisSkill : TooltipTweaks.SubTweak {
     }
 
     protected override DrawConfigDelegate DrawConfigTree => (ref bool hasChanged) => {
-        hasChanged |= ImGui.Checkbox(LocString("Desynthesis Delta") + $"###{GetType().Name}DesynthesisDelta", ref Config.Delta);
+            hasChanged |= ImGui.Checkbox(LocString("Desynthesis Delta") + $"###{GetType().Name}DesynthesisDelta", ref Config.Delta);
+            hasChanged |= ImGui.Checkbox(LocString("Colour Value") + $"##{GetType().Name}ColourValue", ref Config.Colour);
     };
 }

--- a/strings.json
+++ b/strings.json
@@ -515,6 +515,10 @@
     "message": "Desynthesis Delta",
     "description": "[DesynthesisSkill] Show Desynthesis Skill - Desynthesis Delta"
   },
+    "TooltipTweaks@DesynthesisSkill / Colour Value": {
+    "message": "Colour Value",
+    "description": "[DesynthesisSkill] Show Desynthesis Skill - Colour Value"
+  },
   "TooltipTweaks@DesynthesisSkill / Name": {
     "message": "Show Desynthesis Skill",
     "description": "[DesynthesisSkill] Tweak Name"


### PR DESCRIPTION
Similar to daemitus's comment in #50, I like to GC turnin things that isn't going to offer me any skill ups, but rather than desynth first, I'd like to turn in first to clean up inventory, and continue collecting, to build up a bunch to desynth at the same time (and thus optimize use of potions/food).  This commit adds the same coloring idea found in the ExtendedDesynthesisWindow to the Item Hover tooltip making it easy to see in the GC turnin (as well as anywhere I hover).