### PR TITLE
Workaround for Combat Movement

### DIFF
--- a/Tweaks/CombatMovementControl.cs
+++ b/Tweaks/CombatMovementControl.cs
@@ -14,7 +14,7 @@ public unsafe class CombatMovementControl : Tweak {
     private bool inCombat;
 
     public override string Name => "Combat Movement Type Control";
-    public override string Description => "Set movement type between Standard and Legacy when in/out of duty, combat or when weapon is drawn/sheathed. Is Duty configured and you are in Duty, Combat and Weapon will be ignored. Is Combat configuerd and you are in Combat, Weapon will be ignored. ";
+    public override string Description => "Set movement type between Standard and Legacy when in/out of duty, combat or when weapon is drawn/sheathed.\n(Is Duty configured and you are in Duty, Combat and Weapon will be ignored.)\n(Is Combat configuerd and you are in Combat, Weapon will be ignored.)";
     
     public enum MoveModeType {
         Ignore = -1,

--- a/Tweaks/CombatMovementControl.cs
+++ b/Tweaks/CombatMovementControl.cs
@@ -73,9 +73,6 @@ public unsafe class CombatMovementControl : Tweak {
             var v = unsheathedState == 1 ? Config.WeaponDrawn : Config.WeaponSheathed;
             if (v == MoveModeType.Ignore) return;
 
-            ////GameConfig.UiControl.Set("MoveMode", (uint) v);
-
-            var cVal = configModule->GetIntValue(ConfigOption.MoveMode);
             configModule->SetOption(ConfigOption.MoveMode, (int)v);
         }
     }
@@ -87,9 +84,6 @@ public unsafe class CombatMovementControl : Tweak {
             var v = value ? Config.InDuty : Config.OutOfDuty;
             if (v == MoveModeType.Ignore) return;
 
-            ////GameConfig.UiControl.Set("MoveMode", (uint) v);
-
-            var cVal = configModule->GetIntValue(ConfigOption.MoveMode);
             configModule->SetOption(ConfigOption.MoveMode, (int)v);
             inDuty = value;
         }
@@ -99,9 +93,6 @@ public unsafe class CombatMovementControl : Tweak {
             var v = value ? Config.InCombat : Config.OutOfCombat;
             if (v == MoveModeType.Ignore) return;
 
-            ////GameConfig.UiControl.Set("MoveMode", (uint) v);
-
-            var cVal = configModule->GetIntValue(ConfigOption.MoveMode);
             configModule->SetOption(ConfigOption.MoveMode, (int)v);
             inCombat = value;
         }


### PR DESCRIPTION
SetOption to get it working first, plus what I think is a QOL feature InDuty.

Changed to SetOption because TryGetEntry behind GameConfig.UiControl.Set returns 0x0000017f9533b008 but it should be 0x0000017fde128b78.