### PR TITLE
`Improved Interruptable Castbars` Fixes

### DIFF
--- a/Tweaks/UiAdjustment/ImprovedInterruptableCastbars.cs
+++ b/Tweaks/UiAdjustment/ImprovedInterruptableCastbars.cs
@@ -110,6 +110,8 @@ public unsafe class ImprovedInterruptableCastbars : UiAdjustments.SubTweak
     
     private void TryMakeNodes(AtkUnitBase* parent, AtkResNode* positionNode)
     {
+        if (!UiHelper.IsAddonReady(parent)) return;
+        
         var interject = Common.GetNodeByID<AtkImageNode>(&parent->UldManager, InterjectImageNodeId);
         if (interject is null) MakeImageNode(parent, InterjectImageNodeId, 808, positionNode);
 

--- a/Utility/UiHelper.Nodes.cs
+++ b/Utility/UiHelper.Nodes.cs
@@ -60,6 +60,11 @@ public static unsafe partial class UiHelper
 
     public static void LinkNodeAtEnd(AtkImageNode* imageNode, AtkUnitBase* parent)
     {
+        // If the parent, root, or child are null, then the Addon isn't loaded yet.
+        if (parent is null) return;
+        if (parent->RootNode is null) return;
+        if (parent->RootNode->ChildNode is null) return;
+        
         var node = parent->RootNode->ChildNode;
         while (node->PrevSiblingNode != null) node = node->PrevSiblingNode;
 
@@ -72,6 +77,8 @@ public static unsafe partial class UiHelper
 
     public static void LinkNodeAfterTargetNode(AtkImageNode* imageNode, AtkComponentNode* parent, AtkResNode* targetNode)
     {
+        if (parent is null || targetNode is null || imageNode is null) return;
+        
         var prev = targetNode->PrevSiblingNode;
         imageNode->AtkResNode.ParentNode = targetNode->ParentNode;
 
@@ -86,19 +93,18 @@ public static unsafe partial class UiHelper
     
     public static void UnlinkAndFreeImageNode(AtkImageNode* node, AtkUnitBase* parent)
     {
-        if (node != null)
-        {
-            if (node->AtkResNode.PrevSiblingNode != null)
-                node->AtkResNode.PrevSiblingNode->NextSiblingNode = node->AtkResNode.NextSiblingNode;
+        if (node is null || parent is null) return;
+        
+        if (node->AtkResNode.PrevSiblingNode is not null)
+            node->AtkResNode.PrevSiblingNode->NextSiblingNode = node->AtkResNode.NextSiblingNode;
             
-            if (node->AtkResNode.NextSiblingNode != null)
-                node->AtkResNode.NextSiblingNode->PrevSiblingNode = node->AtkResNode.PrevSiblingNode;
+        if (node->AtkResNode.NextSiblingNode is not null)
+            node->AtkResNode.NextSiblingNode->PrevSiblingNode = node->AtkResNode.PrevSiblingNode;
             
-            parent->UldManager.UpdateDrawNodeList();
+        parent->UldManager.UpdateDrawNodeList();
 
-            FreePartsList(node->PartsList);
-            FreeImageNode(node);
-        }
+        FreePartsList(node->PartsList);
+        FreeImageNode(node);
     }
 
     #region TryMakeComponents

--- a/Utility/UiHelper.Nodes.cs
+++ b/Utility/UiHelper.Nodes.cs
@@ -58,13 +58,22 @@ public static unsafe partial class UiHelper
         return imageNode;
     }
 
+    /// <summary>
+    /// Checks if the addon has a valid root and child node.<br/>
+    /// Useful for ensuring that an addon is fully loaded before adding new UI nodes to it.
+    /// </summary>
+    /// <param name="addon">Pointer to addon to check</param>
+    public static bool IsAddonReady(AtkUnitBase* addon)
+    {
+        if (addon is null) return false;
+        if (addon->RootNode is null) return false;
+        if (addon->RootNode->ChildNode is null) return false;
+
+        return true;
+    }
+
     public static void LinkNodeAtEnd(AtkImageNode* imageNode, AtkUnitBase* parent)
     {
-        // If the parent, root, or child are null, then the Addon isn't loaded yet.
-        if (parent is null) return;
-        if (parent->RootNode is null) return;
-        if (parent->RootNode->ChildNode is null) return;
-        
         var node = parent->RootNode->ChildNode;
         while (node->PrevSiblingNode != null) node = node->PrevSiblingNode;
 
@@ -77,8 +86,6 @@ public static unsafe partial class UiHelper
 
     public static void LinkNodeAfterTargetNode(AtkImageNode* imageNode, AtkComponentNode* parent, AtkResNode* targetNode)
     {
-        if (parent is null || targetNode is null || imageNode is null) return;
-        
         var prev = targetNode->PrevSiblingNode;
         imageNode->AtkResNode.ParentNode = targetNode->ParentNode;
 
@@ -93,8 +100,6 @@ public static unsafe partial class UiHelper
     
     public static void UnlinkAndFreeImageNode(AtkImageNode* node, AtkUnitBase* parent)
     {
-        if (node is null || parent is null) return;
-        
         if (node->AtkResNode.PrevSiblingNode is not null)
             node->AtkResNode.PrevSiblingNode->NextSiblingNode = node->AtkResNode.NextSiblingNode;
             


### PR DESCRIPTION
Fixes exception in log that occurs on login when the addons are being constructed internally.

Initially I was going to add additional exception checking in LinkNodeAtEnd, but realized its better for the consumer to check that the addon is valid before attempting to allocate the node.