### PR TITLE
`Expanded Currency Display` Fix Culture

### DIFF
--- a/Tweaks/UiAdjustment/ExpandedCurrencyDisplay.cs
+++ b/Tweaks/UiAdjustment/ExpandedCurrencyDisplay.cs
@@ -312,7 +312,7 @@ public unsafe class ExpandedCurrencyDisplay : UiAdjustments.SubTweak
         var counterNode = (AtkCounterNode*) Common.GetNodeByID(&AddonMoney->UldManager, nodeId);
         if (counterNode is not null)
         {
-            counterNode->SetText(newCount.ToString("n0"));
+            counterNode->SetText(newCount.ToString("n0", Plugin.Culture));
         }
     }
     

--- a/Tweaks/UiAdjustment/ExpandedCurrencyDisplay.cs
+++ b/Tweaks/UiAdjustment/ExpandedCurrencyDisplay.cs
@@ -67,6 +67,7 @@ public unsafe class ExpandedCurrencyDisplay : UiAdjustments.SubTweak
 
     public override void Setup() {
         AddChangelogNewTweak("1.8.3.0");
+        AddChangelog(Changelog.UnreleasedVersion, "Use SimpleTweaks.FormatCulture for number display, should fix French issue");
         base.Setup();
     }
 


### PR DESCRIPTION
Use SimpleTweaks culture for number formatting...

**Maybe** fixes French number display. (Unverified)

![image](https://user-images.githubusercontent.com/9083275/223220242-6bde5445-8557-4cbe-9e5e-6f286495bd49.png)
![image](https://user-images.githubusercontent.com/9083275/223220268-3425229e-a537-4298-a607-3ff898b1f5f9.png)
