### PR TITLE
[`Enhanced Loot Window`] Fix HQ Items

### DIFF
--- a/Tweaks/UiAdjustment/LootWindowDuplicateUniqueItemIndicator.cs
+++ b/Tweaks/UiAdjustment/LootWindowDuplicateUniqueItemIndicator.cs
@@ -184,8 +184,10 @@ public unsafe class LootWindowDuplicateUniqueItemIndicator : UiAdjustments.SubTw
                 var itemInfo = callingAddon->ItemsSpan[index];
                 if (itemInfo.ItemId is 0) continue;
 
+                var adjustedItemId = itemInfo.ItemId > 1_000_000 ? itemInfo.ItemId - 1_000_000 : itemInfo.ItemId;
+                
                 // If we can't match the item in lumina, skip.
-                var itemData = Service.Data.GetExcelSheet<Item>()!.GetRow(itemInfo.ItemId);
+                var itemData = Service.Data.GetExcelSheet<Item>()!.GetRow(adjustedItemId);
                 if(itemData is null) continue;
 
                 var listItemNodeId = listItemNodeIdArray[index];


### PR DESCRIPTION
I haven't tested if this actually fixes this issue, but I believe it to be pretty obviously the reason why it happened.

When the image nodes are created I default them both to visible, and then set them in the OnRequestedUpdate hook.

![image](https://user-images.githubusercontent.com/9083275/226289380-61b1158d-868e-4e70-96af-d892c8bf1018.png)
