### PR TITLE
Make AgentDebug include even agents without a known Id.

### DIFF
--- a/Debugging/AgentDebug.cs
+++ b/Debugging/AgentDebug.cs
@@ -109,9 +109,10 @@ public unsafe class AgentDebug : DebugHelper {
             var l = new List<AgentId>();
             
             var agentClasses = typeof(AgentInterface).Assembly.GetTypes().Select((t) => (t, t.GetCustomAttributes(typeof(AgentAttribute)).Cast<AgentAttribute>().ToArray())).Where(t => t.Item2.Length > 0).ToArray();
-            
-            foreach (var a in Enum.GetValues(typeof(AgentId)).Cast<AgentId>()) {
-                l.Add(a);
+
+            for (int a = 0; a < 425; a++)
+            {
+                l.Add((AgentId)a);
                 if ((uint)a > maxAgentId) {
                     maxAgentId = (uint)a;
                 }


### PR DESCRIPTION
Not sure how you feel about this, but I was looking for some data and wanted to see if there was an agent that was missing.  Since the AgentDebug has the nice "IsActive" capability, I figured it doesn't hurt to include all agents (even those we didn't have a name for).  Might make it easier to help identify agents that haven't yet been named (seeing their open, being able to navigate to their Addon, etc.).