### PR TITLE
Fixing desynthesis item level in CN language

### DIFF
--- a/Tweaks/Tooltips/DesynthesisSkill.cs
+++ b/Tweaks/Tooltips/DesynthesisSkill.cs
@@ -78,7 +78,7 @@ public class DesynthesisSkill : TooltipTweaks.SubTweak {
                     // Turns out .Last() is broken when mixed with AllaganTools for items where the Desynth value is in ItemDescription, as I think AT Adds to the payloads.
                     // And with the original change for colouring, we switched from a simple replace to adding payloads.
                     // For some reason this gets called twice, and with the above change, would result in us adding the desynth skill twice.
-                    var textPayload = seStr.Payloads.OfType<TextPayload>().Where(p => p.Text != null).LastOrDefault(p => p.Text.Contains($": {item.LevelItem.Row},00") || p.Text.Contains($": {item.LevelItem.Row}.00") || p.Text.Contains($":{item.LevelItem.Row}.00"));
+                    var textPayload = seStr.Payloads.OfType<TextPayload>().Where(p => p.Text != null).LastOrDefault(p => p.Text.Contains($": {item.LevelItem.Row},00") || p.Text.Contains($": {item.LevelItem.Row}.00") || p.Text.Contains($":{item.LevelItem.Row}.00") || p.Text.Contains($"：{item.LevelItem.Row}.00"));
                     if (textPayload != null)
                     {
                         // Until we fix AllaganTools, if we're in an ItemDescription, just Replace (and unfortunately don't colour)


### PR DESCRIPTION
I fixed a small bug in the Chinese language text format. The issue occurred in the Addon.csv file, where the full-width colon was causing a problem. 

Here is CN text example
```text
建议分解技能：200.00
https://github.com/thewakingsands/ffxiv-datamining-cn/blob/master/Addon.csv#L1393
```
the text format is $"：{item.LevelItem.Row}.00"

To fix this bug, I add new rule to match item level for cn
