### PR TITLE
[`Materia Stats`] Fix materia cap rounding error

### DIFF
--- a/Tweaks/Tooltips/MateriaStats.cs
+++ b/Tweaks/Tooltips/MateriaStats.cs
@@ -106,7 +106,7 @@ public class MateriaStats : TooltipTweaks.SubTweak {
                 baseParamDeltas.Add(bp.BaseParam.Row, 0);
                 baseParamOriginal.Add(bp.BaseParam.Row, bp.Value);
                 if (bp.BaseParam.Value != null) {
-                    baseParamLimits.Add(bp.BaseParam.Row, (int)Math.Round(itemLevel.BaseParam[bp.BaseParam.Row] * (bp.BaseParam.Value.EquipSlotCategoryPct[item.EquipSlotCategory.Row] / 1000f)));
+                    baseParamLimits.Add(bp.BaseParam.Row, (int)Math.Round(itemLevel.BaseParam[bp.BaseParam.Row] * (bp.BaseParam.Value.EquipSlotCategoryPct[item.EquipSlotCategory.Row] / 1000f), MidpointRounding.AwayFromZero));
                     baseParams.Add(bp.BaseParam.Row, bp.BaseParam.Value);
                 }
             }
@@ -137,7 +137,7 @@ public class MateriaStats : TooltipTweaks.SubTweak {
                     baseParams.Add(materia.BaseParam.Row, bp);
                     baseParamDeltas.Add(materia.BaseParam.Row, materia.Value[*level]);
                     baseParamOriginal.Add(materia.BaseParam.Row, 0);
-                    baseParamLimits.Add(materia.BaseParam.Row, (int) Math.Round(itemLevel.BaseParam[materia.BaseParam.Row] * (bp.EquipSlotCategoryPct[item.EquipSlotCategory.Row] / 1000f)));
+                    baseParamLimits.Add(materia.BaseParam.Row, (int) Math.Round(itemLevel.BaseParam[materia.BaseParam.Row] * (bp.EquipSlotCategoryPct[item.EquipSlotCategory.Row] / 1000f), MidpointRounding.AwayFromZero));
                     continue;
                 }
                 baseParamDeltas[materia.BaseParam.Row] += materia.Value[*level];


### PR DESCRIPTION
The below image shows CP being capped to +10, when the game and other melding sites show +11 as the cap.
[.NET rounds floats and doubles towards even integers](https://stackoverflow.com/a/977807), causing discrepancies where values like 10.5 should've been rounded up towards 11.

![image](https://github.com/Caraxi/SimpleTweaksPlugin/assets/16126912/afbc822a-93f6-451a-af8c-f59f4707d0dd)
