### PR TITLE
[`HideQualityWhenNoHQ`] Fix for expert recipes

### DIFF
--- a/Tweaks/UiAdjustment/HideQualityWhenNoHQ.cs
+++ b/Tweaks/UiAdjustment/HideQualityWhenNoHQ.cs
@@ -11,6 +11,7 @@ public unsafe class HideQualityWhenNoHQ : UiAdjustments.SubTweak {
 
     public override void Setup() {
         AddChangelogNewTweak("1.8.4.0");
+        AddChangelog(Changelog.UnreleasedVersion, "Show quality bar for expert recipes.");
         base.Setup();
     }
     

--- a/Tweaks/UiAdjustment/HideQualityWhenNoHQ.cs
+++ b/Tweaks/UiAdjustment/HideQualityWhenNoHQ.cs
@@ -24,7 +24,7 @@ public unsafe class HideQualityWhenNoHQ : UiAdjustments.SubTweak {
         var agent = AgentRecipeNote.Instance();
         var recipe = Service.Data.GetExcelSheet<Recipe>()?.GetRow(agent->ActiveCraftRecipeId);
         if (recipe == null) return;
-        if (recipe.CanHq) return;
+        if (recipe.CanHq || recipe.IsExpert) return;
         var qualityNode = obj.Addon->GetNodeById(58);
         if (qualityNode == null) return;
         qualityNode->ToggleVisibility(false);


### PR DESCRIPTION
The quality bar should be shown for expert recipes, even though the recipes aren't considered "CanHQ".