### PR TITLE
[`LootWindowSelectNext`] Add New Tweak

### DIFF
--- a/Tweaks/UiAdjustment/LootWindowSelectNext.cs
+++ b/Tweaks/UiAdjustment/LootWindowSelectNext.cs
@@ -1,0 +1,68 @@
+﻿#nullable enable
+using System;
+using Dalamud.Hooking;
+using Dalamud.Logging;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using SimpleTweaksPlugin.Events;
+using SimpleTweaksPlugin.TweakSystem;
+
+namespace SimpleTweaksPlugin.Tweaks.UiAdjustment;
+
+[TweakName("Loot Window Select Next Item")]
+[TweakDescription("Upon pressing 'Need', 'Greed', or 'Pass' automatically select the next loot item.")]
+[TweakAuthor("MidoriKami")]
+[TweakReleaseVersion(UnreleasedVersion)]
+public unsafe class LootWindowSelectNext : UiAdjustments.SubTweak
+{
+    private delegate void NeedGreedReceiveEventDelegate(AddonNeedGreed* addon, AtkEventType type, uint buttonType, AtkEvent* eventInfo, nint data);
+
+    private Hook<NeedGreedReceiveEventDelegate>? needGreedReceiveEventHook;
+
+    [AddonSetup("NeedGreed")]
+    private void AddonSetup(AtkUnitBase* atkUnitBase)
+    {
+        if (atkUnitBase is null) return;
+        
+        needGreedReceiveEventHook ??= Hook<NeedGreedReceiveEventDelegate>.FromAddress((nint) atkUnitBase->AtkEventListener.vfunc[2], OnNeedGreedReceiveEvent);
+        needGreedReceiveEventHook?.Enable();
+    }
+
+    protected override void Disable()
+    {
+        needGreedReceiveEventHook?.Disable();
+        base.Disable();
+    }
+
+    public override void Dispose()
+    {
+        needGreedReceiveEventHook?.Dispose();
+        base.Dispose();
+    }
+
+    private void OnNeedGreedReceiveEvent(AddonNeedGreed* addon, AtkEventType type, uint buttonType, AtkEvent* eventInfo, nint data)
+    {
+        needGreedReceiveEventHook!.Original(addon, type, buttonType, eventInfo, data);
+        
+        try
+        {
+            // ButtonType 3 and 0 are for "Loot Recipient" and "Greed Only"
+            if (type is AtkEventType.ButtonClick && buttonType is not 3 and not 0)
+            {
+                var currentSelectedItem = *((byte*) addon + 0x508);
+                var currentItemCount = addon->AtkUnitBase.AtkValues[3].UInt;
+                var nextIndex = currentSelectedItem + 1;
+
+                if (nextIndex == currentItemCount) nextIndex = 0;
+
+                var values = stackalloc int[6];
+                values[4] = nextIndex;
+                OnNeedGreedReceiveEvent(addon, AtkEventType.ListItemToggle, 0, null, (nint)values);
+            }
+        }
+        catch (Exception exception)
+        {
+            PluginLog.Error(exception, "Something went wrong in 'Loot Window Select Next Item', let MidoriKami know.");
+        }
+    }
+}

--- a/Tweaks/UiAdjustment/LootWindowSelectNext.cs
+++ b/Tweaks/UiAdjustment/LootWindowSelectNext.cs
@@ -65,7 +65,11 @@ public unsafe class LootWindowSelectNext : UiAdjustments.SubTweak
                 case 0: // Need
                 case 1: // Greed
                 case 2 when GetSelectedItem(addon) is { Roll: 0, ItemId: not 0 }: // Pass, don't select next item if we are passing on an item that we already rolled on
-                    SetSelectNextItem(addon);
+                    var currentItemCount = addon->AtkUnitBase.AtkValues[3].UInt;
+                    var nextIndex = addon->SelectedItemIndex + 1;
+                    if (nextIndex == currentItemCount) nextIndex = 0;
+                    
+                    SelectItem(addon, nextIndex);
                     break;
             }
         }
@@ -73,16 +77,6 @@ public unsafe class LootWindowSelectNext : UiAdjustments.SubTweak
         {
             PluginLog.Error(exception, "Something went wrong in 'Loot Window Select Next Item', let MidoriKami know.");
         }
-    }
-
-    private void SetSelectNextItem(AddonNeedGreed* addon)
-    {
-        var currentItemCount = addon->AtkUnitBase.AtkValues[3].UInt;
-        var nextIndex = addon->SelectedItemIndex + 1;
-        
-        if (nextIndex == currentItemCount) nextIndex = 0;
-        
-        SelectItem(addon, nextIndex);
     }
 
     private void SelectItem(AddonNeedGreed* addon, int index)

--- a/Tweaks/UiAdjustment/LootWindowSelectNext.cs
+++ b/Tweaks/UiAdjustment/LootWindowSelectNext.cs
@@ -73,7 +73,7 @@ public unsafe class LootWindowSelectNext : UiAdjustments.SubTweak
                 case ButtonType.Need:
                 case ButtonType.Greed:
                 case ButtonType.Pass when IsSelectedItemUnrolled(addon): // Don't select next item if we are passing on an item that we already rolled on
-                    var currentItemCount = addon->AtkUnitBase.AtkValues[3].UInt;
+                    var currentItemCount = addon->NumItems;
                     var nextIndex = addon->SelectedItemIndex + 1;
                     
                     if (nextIndex < currentItemCount) SelectItem(addon, nextIndex);

--- a/Tweaks/UiAdjustment/LootWindowSelectNext.cs
+++ b/Tweaks/UiAdjustment/LootWindowSelectNext.cs
@@ -66,7 +66,7 @@ public unsafe class LootWindowSelectNext : UiAdjustments.SubTweak
     private void SetSelectNextItem(AddonNeedGreed* addon)
     {
         var currentItemCount = addon->AtkUnitBase.AtkValues[3].UInt;
-        var nextIndex = GetSelectedItemIndex(addon) + 1;
+        var nextIndex = addon->SelectedItemIndex + 1;
         
         if (nextIndex == currentItemCount) nextIndex = 0;
         
@@ -76,8 +76,5 @@ public unsafe class LootWindowSelectNext : UiAdjustments.SubTweak
     }
 
     private LootItemInfo GetSelectedItem(AddonNeedGreed* addon) 
-        => addon->ItemsSpan[GetSelectedItemIndex(addon)];
-
-    private int GetSelectedItemIndex(AddonNeedGreed* addon)
-        => *(int*)((byte*) addon + 0x508);
+        => addon->ItemsSpan[addon->SelectedItemIndex];
 }


### PR DESCRIPTION
Depends on unmerged clientstructs PR: https://github.com/aers/FFXIVClientStructs/pull/528

Alternatively I could include a copy of these structs in the tweak.

This tweak will automatically select the next item in the loot list after clicking "need" "greed" or "pass"
No decisions are being made on behalf of the user, and no data is being sent to the servers.

This tweak does not pass-all, greed-all, or need-all, it only advances the selected item one spot each time "need" "greed" or "pass" is pressed.

There seems to be some kind of built in rate-limit already in the vanilla button events that prevents a user from rolling on items unreasonably quickly. (See attached clip to see what happens when you spam click)

https://github.com/Caraxi/SimpleTweaksPlugin/assets/9083275/8ad65d44-aac5-4568-ac67-c0ca4ab560bf

