### PR TITLE
[`EnhancedLootWindow`] Ban Enhanced Loot Window

### DIFF
--- a/tweakBlacklist.txt
+++ b/tweakBlacklist.txt
@@ -3,3 +3,4 @@ FixedShadowDistance
 RefreshMarketPrices
 TooltipTweaks
 UiAdjustments@DutyListBackground
+UiAdjustments@LootWindowDuplicateUniqueItemIndicator


### PR DESCRIPTION
Dalamud updated its ClientStructs, so now they have a span that is size 16 and the live version of this tweak is indexing to size 32.

This PR is an alternative to releasing a SimpleTweaks update.