### PR TITLE
`Debug` Fix error spam

### DIFF
--- a/SimpleTweaksPlugin.cs
+++ b/SimpleTweaksPlugin.cs
@@ -468,8 +468,8 @@ namespace SimpleTweaksPlugin {
         }
         
         public void Error(BaseTweak tweak, Exception exception, bool allowContinue = false, string message = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string callerMemberName = "" ) {
-            if (tweak == null) {
-                SimpleLog.Error($"Exception in '{tweak?.Name ?? "NonTweakSource"}'" + (string.IsNullOrEmpty(message) ? "" : ($": {message}")), callerFilePath, callerMemberName, callerLineNumber);
+            if (tweak != null) {
+                SimpleLog.Error($"Exception in '{tweak}'" + (string.IsNullOrEmpty(message) ? "" : ($": {message}")), callerFilePath, callerMemberName, callerLineNumber);
             } else {
                 SimpleLog.Error("Exception in SimpleTweaks framework. "+ (string.IsNullOrEmpty(message) ? "" : ($": {message}")), callerFilePath, callerMemberName, callerLineNumber);
             }

--- a/SimpleTweaksPlugin.cs
+++ b/SimpleTweaksPlugin.cs
@@ -469,7 +469,7 @@ namespace SimpleTweaksPlugin {
         
         public void Error(BaseTweak tweak, Exception exception, bool allowContinue = false, string message = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string callerMemberName = "" ) {
             if (tweak != null) {
-                SimpleLog.Error($"Exception in '{tweak}'" + (string.IsNullOrEmpty(message) ? "" : ($": {message}")), callerFilePath, callerMemberName, callerLineNumber);
+                SimpleLog.Error($"Exception in '{tweak.Name}'" + (string.IsNullOrEmpty(message) ? "" : ($": {message}")), callerFilePath, callerMemberName, callerLineNumber);
             } else {
                 SimpleLog.Error("Exception in SimpleTweaks framework. "+ (string.IsNullOrEmpty(message) ? "" : ($": {message}")), callerFilePath, callerMemberName, callerLineNumber);
             }

--- a/SimpleTweaksPlugin.cs
+++ b/SimpleTweaksPlugin.cs
@@ -469,7 +469,7 @@ namespace SimpleTweaksPlugin {
         
         public void Error(BaseTweak tweak, Exception exception, bool allowContinue = false, string message = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string callerMemberName = "" ) {
             if (tweak == null) {
-                SimpleLog.Error($"Exception in '{tweak.Name}'" + (string.IsNullOrEmpty(message) ? "" : ($": {message}")), callerFilePath, callerMemberName, callerLineNumber);
+                SimpleLog.Error($"Exception in '{tweak?.Name ?? "NonTweakSource"}'" + (string.IsNullOrEmpty(message) ? "" : ($": {message}")), callerFilePath, callerMemberName, callerLineNumber);
             } else {
                 SimpleLog.Error("Exception in SimpleTweaks framework. "+ (string.IsNullOrEmpty(message) ? "" : ($": {message}")), callerFilePath, callerMemberName, callerLineNumber);
             }


### PR DESCRIPTION
Fixes error spam on framework when SimpleTweaks.Plugin.Error is called without a tweak parameter.

![image](https://github.com/Caraxi/SimpleTweaksPlugin/assets/9083275/77a7480a-4442-478e-b8b3-c04a0034e54b)
