### PR TITLE
Various typo and grammar fixes for tweak descriptions

### DIFF
--- a/Tweaks/Chat/StickyChat.cs
+++ b/Tweaks/Chat/StickyChat.cs
@@ -12,7 +12,7 @@ namespace SimpleTweaksPlugin.Tweaks.Chat;
 public unsafe partial class StickyChat : ChatTweaks.SubTweak
 {
     public override string Name => "Sticky Chat";
-    public override string Description => "Sets chat channel when you use temporary chat messages.\nExample: \"/p hello!\" will set the chat channel to Party";
+    public override string Description => "Sets the chat channel when you use temporary chat messages.\nExample: \"/p hello!\" will set the chat channel to Party";
     protected override string Author => "MidoriKami";
 
     private delegate byte ProcessChatInputDelegate(nint uiModule, byte** message, nint a3);

--- a/Tweaks/ChrDirCommand.cs
+++ b/Tweaks/ChrDirCommand.cs
@@ -12,7 +12,7 @@ namespace SimpleTweaksPlugin.Tweaks;
 
 public class ChrDirCommand : CommandTweak {
     public override string Name => "Character Directory Command";
-    public override string Description => "Adds a command to open the directory when client side character data is stored.";
+    public override string Description => "Adds a command to open the directory where client side character data is stored.";
     protected override string Command => "chrdir";
     protected override string HelpMessage => "Print your character save directory to chat. '/chrdir open' to open the directory in explorer.";
 

--- a/Tweaks/SmartStrafe.cs
+++ b/Tweaks/SmartStrafe.cs
@@ -9,7 +9,7 @@ namespace SimpleTweaksPlugin.Tweaks
 {
     internal class SmartStrafe : Tweak {
         public override string Name => "Smart Strafe";
-        public override string Description => "Inteligently switches keyboard controls between strafing and turning.\n(Legacy type movement only)";
+        public override string Description => "Intelligently switches keyboard controls between strafing and turning.\n(Legacy type movement only)";
         protected override string Author => "Iryoku";
 
         public enum Mode {

--- a/Tweaks/Tooltips/TrackFadedRolls.cs
+++ b/Tweaks/Tooltips/TrackFadedRolls.cs
@@ -17,7 +17,7 @@ public unsafe class TrackFadedRolls : TooltipTweaks.SubTweak {
     
     public override string Name => "Track Faded Orchestrion Rolls";
     protected override string Author => "KazWolfe";
-    public override string Description => "Adds the collected checkmark to Faded Orchestrion Rolls.";
+    public override string Description => "Adds the collectable checkmark to Faded Orchestrion Rolls.";
     
     private delegate byte IsItemActionUnlocked(UIState* uiState, IntPtr item);
     private HookWrapper<IsItemActionUnlocked>? _isItemActionUnlockedHookWrapper;

--- a/Tweaks/UiAdjustment/ActionPressMirroring.cs
+++ b/Tweaks/UiAdjustment/ActionPressMirroring.cs
@@ -22,7 +22,7 @@ public unsafe class ActionPressMirroring : UiAdjustments.SubTweak
     private bool tweakIsPulsing = false;
 
     public override string Name => "Duplicate Action Presses Between Hotbars";
-    public override string Description => "Will show the action press pulse on all hotbar slots with the same ability when you use it.";
+    public override string Description => "Shows the pulse effect when activating actions, even if they are duplicated between hotbars.";
     protected override string Author => "BoredDan";
 
     private static readonly string[] allActionBars = {

--- a/Tweaks/UiAdjustment/AlwaysYes.cs
+++ b/Tweaks/UiAdjustment/AlwaysYes.cs
@@ -11,7 +11,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment;
 
 public unsafe class AlwaysYes : UiAdjustments.SubTweak {
     public override string Name => "Always Yes";
-    public override string Description => "Default cursor to yes when using confirm (num 0).";
+    public override string Description => "Sets the default action in dialog boxes to yes when using confirm (num 0).";
     protected override string Author => "Aireil";
 
     public class Configs : TweakConfig {

--- a/Tweaks/UiAdjustment/ReducedDeepDungeonInfo.cs
+++ b/Tweaks/UiAdjustment/ReducedDeepDungeonInfo.cs
@@ -12,7 +12,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment;
 
 public unsafe class ReducedDeepDungeonInfo : UiAdjustments.SubTweak {
     public override string Name => "Reduced Deep Dungeon Info";
-    public override string Description => "Removes the redundant infos from the deep dungeon character info.";
+    public override string Description => "Removes redundant information from the deep dungeon character info.";
     protected override string Author => "Aireil";
 
     protected override void Enable() {


### PR DESCRIPTION
This changes the Chat, ChrDirCommand, SmartStrafe, Tooltips, ActionPressMirroring, AlwaysYes, FadeUnavailableActions, and ReducedDeepDungeonInfo tweak descriptions to fix various errors.

These edits are so small I piled it into one big PR, let me know if I should separate them instead.