### PR TITLE
[`EnhancedLootWindow`] Fix freeing of image nodes during finalize

### DIFF
--- a/Tweaks/UiAdjustment/LootWindowDuplicateUniqueItemIndicator.cs
+++ b/Tweaks/UiAdjustment/LootWindowDuplicateUniqueItemIndicator.cs
@@ -28,8 +28,6 @@ public unsafe class LootWindowDuplicateUniqueItemIndicator : UiAdjustments.SubTw
     [Signature("40 53 48 83 EC 20 48 8B 42 58", DetourName = nameof(OnNeedGreedRequestedUpdate))]
     private readonly Hook<OnRequestedUpdateDelegate>? needGreedOnRequestedUpdateHook = null!;
 
-    private static AtkUnitBase* AddonNeedGreed => (AtkUnitBase*) Service.GameGui.GetAddonByName("NeedGreed");
-
     private readonly int[] listItemNodeIdArray = Enumerable.Range(21001, 31).Prepend(2).ToArray();
 
     private const uint CrossBaseId = 1000U;
@@ -138,17 +136,19 @@ public unsafe class LootWindowDuplicateUniqueItemIndicator : UiAdjustments.SubTw
                     
             var lootItemNode = Common.GetNodeByID<AtkComponentNode>(componentUldManager, index);
             if (lootItemNode is null) continue;
-            
-            var crossNode = Common.GetNodeByID<AtkImageNode>(componentUldManager, CrossBaseId + index);
+
+            var lootItemUldManager = &lootItemNode->Component->UldManager;
+
+            var crossNode = Common.GetNodeByID<AtkImageNode>(lootItemUldManager, CrossBaseId + index);
             if (crossNode is not null)
             {
-                UiHelper.UnlinkAndFreeImageNode(crossNode, AddonNeedGreed);
+                UiHelper.UnlinkAndFreeImageNode(crossNode, obj.Addon);
             }
                         
-            var padlockNode = Common.GetNodeByID<AtkImageNode>(componentUldManager, PadlockBaseId + index);
+            var padlockNode = Common.GetNodeByID<AtkImageNode>(lootItemUldManager, PadlockBaseId + index);
             if (padlockNode is not null)
             {
-                UiHelper.UnlinkAndFreeImageNode(padlockNode, AddonNeedGreed);
+                UiHelper.UnlinkAndFreeImageNode(padlockNode, obj.Addon);
             }
         }
     }


### PR DESCRIPTION
Let me start off by saying I'm not familiar with native UI at all so many assumptions I've made here could be totally wrong.

When working on a loot window modification using this tweak as a base, I noticed that `UiHelper.UnlinkAndFreeImageNode` wasn't being called (successfully or at all). This was due to two issues:

1. The first issue was that `crossNode` and `padlockNode` could not be found during addon finalize. I fixed this by looking for them in `lootItemNode`'s `UldManager` instead of the list component's `UldManager`. This is what `UpdateNodeVisibility` does and it seems to be correct.
2. After fixing the above, the second issue was that `AddonNeedGreed` (which is passed to `UiHelper.UnlinkAndFreeImageNode`) was returning a null pointer during finalize. I guess at this stage of finalization the manager is already gone? ~~However I couldn't pass the owning component either since it's an `AtkComponentBase*` (and not an `AtkUnitBase*` which the existing function wants). So I just created a copy of `UnlinkAndFreeImageNode` which accepts an `AtkUldManager*` directly, which seemed to work. I'm not sure if this is correct or not (do we also need to do something in the parent?).~~ So instead of using that, I get the addon reference via `SetupAddonArgs`.

Note that the old behavior didn't seem to actually cause any problems, so I really don't know how important or necessary this fix is. But I guess we're trying to free nodes for a reason, and from my testing this should fix that.

Let me know if any of the above assumptions are incorrect or if there's a better way to do any of this.