### PR TITLE
[`ShowShieldOnHPBar`] Fix bar color

### DIFF
--- a/Tweaks/UiAdjustment/ShowShieldOnHPBar.cs
+++ b/Tweaks/UiAdjustment/ShowShieldOnHPBar.cs
@@ -106,9 +106,9 @@ public unsafe class ShowShieldOnHPBar: UiAdjustments.SubTweak
                 bar->AtkResNode.MultiplyRed = 255;
                 bar->AtkResNode.MultiplyGreen = 255;
                 bar->AtkResNode.MultiplyBlue = 0;
-                bar->AtkResNode.AddRed = 0;
-                bar->AtkResNode.AddGreen = 0;
-                bar->AtkResNode.AddBlue = 0;
+                bar->AtkResNode.AddRed = -1;
+                bar->AtkResNode.AddGreen = -1;
+                bar->AtkResNode.AddBlue = -1;
                 bar->AtkResNode.Width = 0;
                 bar->AtkResNode.DrawFlags |= 1;
                 bar->AtkResNode.SetHeight(20);

--- a/Tweaks/UiAdjustment/ShowShieldOnHPBar.cs
+++ b/Tweaks/UiAdjustment/ShowShieldOnHPBar.cs
@@ -106,9 +106,9 @@ public unsafe class ShowShieldOnHPBar: UiAdjustments.SubTweak
                 bar->AtkResNode.MultiplyRed = 255;
                 bar->AtkResNode.MultiplyGreen = 255;
                 bar->AtkResNode.MultiplyBlue = 0;
-                bar->AtkResNode.AddRed = short.MaxValue;
-                bar->AtkResNode.AddGreen = short.MaxValue;
-                bar->AtkResNode.AddBlue = short.MaxValue;
+                bar->AtkResNode.AddRed = 0;
+                bar->AtkResNode.AddGreen = 0;
+                bar->AtkResNode.AddBlue = 0;
                 bar->AtkResNode.Width = 0;
                 bar->AtkResNode.DrawFlags |= 1;
                 bar->AtkResNode.SetHeight(20);


### PR DESCRIPTION
It was previously thought that `AddRed` etc. were `ushort`, but they are actually `short`. This code used to work by coincidence because `ushort.MaxValue` is -1 when read as a `short`, but now it results in a pure white bar. Probably they should just be zero.