### PR TITLE
[`LootWindowSelectNext`] Modernize Tweak

### DIFF
--- a/Tweaks/UiAdjustment/LootWindowSelectNext.cs
+++ b/Tweaks/UiAdjustment/LootWindowSelectNext.cs
@@ -16,6 +16,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment;
 public unsafe class LootWindowSelectNext : UiAdjustments.SubTweak {
     private delegate void NeedGreedReceiveEventDelegate(AddonNeedGreed* addon, AtkEventType type, ButtonType buttonType, AtkEvent* eventInfo, nint data);
 
+    [TweakHook(AutoEnable = false)]
     private HookWrapper<NeedGreedReceiveEventDelegate>? needGreedReceiveEventHook;
 
     [AddonPostSetup("NeedGreed")]
@@ -31,16 +32,6 @@ public unsafe class LootWindowSelectNext : UiAdjustments.SubTweak {
                 break;
             }
         }
-    }
-
-    protected override void Disable() {
-        needGreedReceiveEventHook?.Disable();
-        base.Disable();
-    }
-
-    public override void Dispose() {
-        needGreedReceiveEventHook?.Dispose();
-        base.Dispose();
     }
 
     // There are other button types such as "Greed Only" and "Loot Recipient"

--- a/Tweaks/UiAdjustment/LootWindowSelectNext.cs
+++ b/Tweaks/UiAdjustment/LootWindowSelectNext.cs
@@ -13,62 +13,50 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment;
 [TweakDescription("Upon pressing 'Need', 'Greed', or 'Pass' automatically select the next loot item.")]
 [TweakAuthor("MidoriKami")]
 [TweakReleaseVersion("1.8.9.2")]
-public unsafe class LootWindowSelectNext : UiAdjustments.SubTweak
-{
+public unsafe class LootWindowSelectNext : UiAdjustments.SubTweak {
     private delegate void NeedGreedReceiveEventDelegate(AddonNeedGreed* addon, AtkEventType type, ButtonType buttonType, AtkEvent* eventInfo, nint data);
 
     private HookWrapper<NeedGreedReceiveEventDelegate>? needGreedReceiveEventHook;
 
     [AddonPostSetup("NeedGreed")]
-    private void AddonSetup(AtkUnitBase* atkUnitBase)
-    {
-        if (atkUnitBase is null) return;
-        
+    private void AddonSetup(AtkUnitBase* atkUnitBase) {
         needGreedReceiveEventHook ??= Common.Hook<NeedGreedReceiveEventDelegate>((nint) atkUnitBase->AtkEventListener.vfunc[2], OnNeedGreedReceiveEvent);
         needGreedReceiveEventHook?.Enable();
 
         // Find first item that hasn't been rolled on, and select it.
         var addonNeedGreed = (AddonNeedGreed*) atkUnitBase;
-        foreach (var index in Enumerable.Range(0, addonNeedGreed->NumItems))
-        {
-            if (addonNeedGreed->ItemsSpan[index] is { Roll: 0, ItemId: not 0 })
-            {
+        foreach (var index in Enumerable.Range(0, addonNeedGreed->NumItems)) {
+            if (addonNeedGreed->ItemsSpan[index] is { Roll: 0, ItemId: not 0 }) {
                 SelectItem(addonNeedGreed, index);
                 break;
             }
         }
     }
 
-    protected override void Disable()
-    {
+    protected override void Disable() {
         needGreedReceiveEventHook?.Disable();
         base.Disable();
     }
 
-    public override void Dispose()
-    {
+    public override void Dispose() {
         needGreedReceiveEventHook?.Dispose();
         base.Dispose();
     }
 
     // There are other button types such as "Greed Only" and "Loot Recipient"
-    private enum ButtonType : uint
-    {
+    private enum ButtonType : uint {
         Need = 0,
         Greed = 1,
         Pass = 2,
     }
 
-    private void OnNeedGreedReceiveEvent(AddonNeedGreed* addon, AtkEventType type, ButtonType buttonType, AtkEvent* eventInfo, nint data)
-    {
+    private void OnNeedGreedReceiveEvent(AddonNeedGreed* addon, AtkEventType type, ButtonType buttonType, AtkEvent* eventInfo, nint data) {
         needGreedReceiveEventHook!.Original(addon, type, buttonType, eventInfo, data);
         
-        try
-        {
+        try {
             if (type is not AtkEventType.ButtonClick) return;
 
-            switch (buttonType)
-            {
+            switch (buttonType) {
                 case ButtonType.Need:
                 case ButtonType.Greed:
                 case ButtonType.Pass when IsSelectedItemUnrolled(addon): // Don't select next item if we are passing on an item that we already rolled on
@@ -78,15 +66,12 @@ public unsafe class LootWindowSelectNext : UiAdjustments.SubTweak
                     if (nextIndex < currentItemCount) SelectItem(addon, nextIndex);
                     break;
             }
-        }
-        catch (Exception exception)
-        {
+        } catch (Exception exception) {
             SimpleLog.Error(exception, "Something went wrong in 'Loot Window Select Next Item', let MidoriKami know.");
         }
     }
 
-    private void SelectItem(AddonNeedGreed* addon, int index)
-    {
+    private void SelectItem(AddonNeedGreed* addon, int index) {
         var values = stackalloc int[6];
         values[4] = index;
         OnNeedGreedReceiveEvent(addon, AtkEventType.ListItemToggle, 0, null, (nint)values); 


### PR DESCRIPTION
Removed the null check from AddonSetup, because AddonLifecycle literally can't be called from a null addon pointer.