### PR TITLE
[`EventController`] Additional Events

### DIFF
--- a/Debugging/EventsDebugging.cs
+++ b/Debugging/EventsDebugging.cs
@@ -14,25 +14,35 @@ public unsafe class EventsDebugging : DebugHelper {
     
     private Dictionary<AddonEvent, Dictionary<string, List<EventController.EventSubscriber>>>? addonEventDict;
     private List<EventController.EventSubscriber> frameworkSubscribers;
+    private List<EventController.EventSubscriber> territoryChangedSubscribers;
     
     private bool viewingFramework = false;
+    private bool viewingTerritoryChanged = false;
     private AddonEvent selectedType;
     
     public override void Draw() {
         addonEventDict ??= (Dictionary<AddonEvent, Dictionary<string, List<EventController.EventSubscriber>>>)typeof(EventController).GetProperty("AddonEventSubscribers", BindingFlags.Static | BindingFlags.NonPublic)?.GetValue(null);
         frameworkSubscribers ??= (List<EventController.EventSubscriber>)typeof(EventController).GetProperty("FrameworkUpdateSubscribers", BindingFlags.Static | BindingFlags.NonPublic)?.GetValue(null);
-
-        if (addonEventDict == null || frameworkSubscribers == null) return;
+        territoryChangedSubscribers ??= (List<EventController.EventSubscriber>)typeof(EventController).GetProperty("TerritoryChangedSubscribers", BindingFlags.Static | BindingFlags.NonPublic)?.GetValue(null);
+        
+        if (addonEventDict == null || frameworkSubscribers == null || territoryChangedSubscribers == null) return;
         
         if (ImGui.BeginChild("eventTypeSelect", new Vector2(200 * ImGuiHelpers.GlobalScale, ImGui.GetContentRegionAvail().Y), true)) {
             if (ImGui.Selectable("Framework", viewingFramework)) {
                 viewingFramework = true;
+                viewingTerritoryChanged = false;
+            }
+
+            if (ImGui.Selectable("TerritoryChanged", viewingTerritoryChanged)) {
+                viewingTerritoryChanged = true;
+                viewingFramework = false;
             }
             
             foreach (var t in Enum.GetValues<AddonEvent>()) {
                 ImGui.BeginDisabled(addonEventDict == null || !addonEventDict!.ContainsKey(t));
-                if (ImGui.Selectable($"{t}", selectedType == t && viewingFramework == false)) {
+                if (ImGui.Selectable($"{t}", selectedType == t && viewingFramework == false && viewingTerritoryChanged == false)) {
                     viewingFramework = false;
+                    viewingTerritoryChanged = false;
                     selectedType = t;
                 }
                 ImGui.EndDisabled();
@@ -42,7 +52,19 @@ public unsafe class EventsDebugging : DebugHelper {
         ImGui.SameLine();
         if (ImGui.BeginChild("events", ImGui.GetContentRegionAvail(), true)) {
             if (viewingFramework) {
+                ImGui.SetWindowFontScale(1.25f);
+                ImGui.Text($"Framework");
+                ImGui.Separator();
+                ImGui.SetWindowFontScale(1f);
+                
                 ShowEventList(frameworkSubscribers, true);
+            } else if (viewingTerritoryChanged) {
+                ImGui.SetWindowFontScale(1.25f);
+                ImGui.Text($"TerritoryChanged");
+                ImGui.Separator();
+                ImGui.SetWindowFontScale(1f);
+                
+                ShowEventList(territoryChangedSubscribers, true);
             } else {
                 if (addonEventDict.TryGetValue(selectedType, out var selectedTypeDict)) {
                     var h = true;

--- a/Events/AddonEventAttribute.cs
+++ b/Events/AddonEventAttribute.cs
@@ -59,4 +59,12 @@ public class AddonPostRefreshAttribute : AddonEventAttribute {
     public AddonPostRefreshAttribute(params string[] addonNames) : base(AddonEvent.PostRefresh, addonNames) { }
 }
 
+public class AddonPreReceiveEventAttribute : AddonEventAttribute {
+    public AddonPreReceiveEventAttribute(params string[] addonNames) : base(AddonEvent.PreReceiveEvent, addonNames) { }
+}
+
+public class AddonPostReceiveEventAttribute : AddonEventAttribute {
+    public AddonPostReceiveEventAttribute(params string[] addonNames) : base(AddonEvent.PostReceiveEvent, addonNames) { }
+}
+
 #endregion

--- a/Events/TerritoryChangedAttribute.cs
+++ b/Events/TerritoryChangedAttribute.cs
@@ -1,0 +1,5 @@
+﻿namespace SimpleTweaksPlugin.Events; 
+
+public class TerritoryChangedAttribute : EventAttribute {
+    
+}

--- a/Tweaks/AutoLockHotbar.cs
+++ b/Tweaks/AutoLockHotbar.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Game.ClientState.Conditions;
+using SimpleTweaksPlugin.Events;
 using SimpleTweaksPlugin.TweakSystem;
 using SimpleTweaksPlugin.Utility;
 
@@ -22,7 +23,6 @@ public unsafe class AutoLockHotbar : Tweak {
 
     protected override void Enable() {
         Config = LoadConfig<Configs>() ?? new Configs();
-        Service.ClientState.TerritoryChanged += OnTerritoryChanged;
         Service.Condition.ConditionChange += OnConditionChange;
         base.Enable();
     }
@@ -31,12 +31,12 @@ public unsafe class AutoLockHotbar : Tweak {
         if (Config.CombatStart && flag == ConditionFlag.InCombat && value) SetLock(true);
     }
 
+    [TerritoryChanged]
     private void OnTerritoryChanged(ushort _) {
         if (Config.ZoneChange) SetLock(true);
     }
 
     protected override void Disable() {
-        Service.ClientState.TerritoryChanged -= OnTerritoryChanged;
         Service.Condition.ConditionChange -= OnConditionChange;
         SaveConfig(Config);
         base.Disable();

--- a/Tweaks/Chat/EchoPartyFinder.cs
+++ b/Tweaks/Chat/EchoPartyFinder.cs
@@ -42,15 +42,8 @@ public unsafe class EchoPartyFinder : ChatTweaks.SubTweak {
     public override void Setup() {
         onLookingForGroupEventHook ??= Common.Hook(AgentModule.Instance()->GetAgentByInternalId(AgentId.LookingForGroup)->VTable->ReceiveEvent, new ReceiveEventDelegate(OnLookingForGroupReceiveEvent));
     }
-
-    protected override void Enable() {
-        Service.ClientState.TerritoryChanged += OnTerritoryChanged;
-    }
-
-    protected override void Disable() {
-        Service.ClientState.TerritoryChanged -= OnTerritoryChanged;
-    }
-
+    
+    [TerritoryChanged]
     private void OnTerritoryChanged(ushort territoryId) {
         if (territoryId != targetTerritoryId) return;
         if (TweakConfig.ShowUponEnteringInstance) PrintListing();

--- a/Tweaks/Chat/HideChatPanelButtons.cs
+++ b/Tweaks/Chat/HideChatPanelButtons.cs
@@ -1,4 +1,5 @@
 ﻿using FFXIVClientStructs.FFXIV.Component.GUI;
+using SimpleTweaksPlugin.Events;
 using SimpleTweaksPlugin.Utility;
 
 namespace SimpleTweaksPlugin.Tweaks.Chat; 
@@ -10,11 +11,11 @@ public unsafe class HideChatPanelButtons : ChatTweaks.SubTweak {
     private readonly string[] panels = { "ChatLogPanel_1", "ChatLogPanel_2", "ChatLogPanel_3" };
 
     protected override void Enable() {
-        Service.ClientState.TerritoryChanged += TerritoryChange;
         ToggleButtons(false);
         base.Enable();
     }
 
+    [TerritoryChanged]
     private void TerritoryChange(ushort territory) => ToggleButtons(false);
 
     private void ToggleButtons(AtkUnitBase* atkUnitBase, bool visible) {
@@ -33,7 +34,6 @@ public unsafe class HideChatPanelButtons : ChatTweaks.SubTweak {
     }
 
     protected override void Disable() {
-        Service.ClientState.TerritoryChanged -= TerritoryChange;
         ToggleButtons(true);
         base.Disable();
     }

--- a/Tweaks/UiAdjustment/MinimapAdjustments.cs
+++ b/Tweaks/UiAdjustment/MinimapAdjustments.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Numerics;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using ImGuiNET;
+using SimpleTweaksPlugin.Events;
 using SimpleTweaksPlugin.TweakSystem;
 using SimpleTweaksPlugin.Utility;
 
@@ -64,11 +65,11 @@ public unsafe class MinimapAdjustments : UiAdjustments.SubTweak {
     protected override void Enable() {
         Config = LoadConfig<Configs>() ?? new Configs();
         Service.ClientState.Login += OnLogin;
-        Service.ClientState.TerritoryChanged += OnTerritoryChanged;
         base.Enable();
         Update();
     }
 
+    [TerritoryChanged]
     private void OnTerritoryChanged(ushort _) {
         sw.Restart();
         Common.FrameworkUpdate -= WaitForUpdate;

--- a/Tweaks/UiAdjustment/ParameterBarAdjustments.cs
+++ b/Tweaks/UiAdjustment/ParameterBarAdjustments.cs
@@ -7,6 +7,7 @@ using Dalamud.Interface;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using ImGuiNET;
 using Lumina.Excel.GeneratedSheets;
+using SimpleTweaksPlugin.Events;
 using SimpleTweaksPlugin.TweakSystem;
 using SimpleTweaksPlugin.Utility;
 
@@ -75,20 +76,17 @@ public unsafe class ParameterBarAdjustments : UiAdjustments.SubTweak {
         }
 
         Config = LoadConfig<Configs>() ?? new Configs();
-        Common.FrameworkUpdate += OnFrameworkUpdate;
-        Service.ClientState.TerritoryChanged += OnTerritoryChanged;
         OnTerritoryChanged(Service.ClientState.TerritoryType);
         base.Enable();
     }
 
     protected override void Disable() {
-        Common.FrameworkUpdate -= OnFrameworkUpdate;
-        Service.ClientState.TerritoryChanged -= OnTerritoryChanged;
         UpdateParameterBar(true);
         SaveConfig(Config);
         base.Disable();
     }
 
+    [FrameworkUpdate]
     private void OnFrameworkUpdate() {
         try {
             UpdateParameterBar();
@@ -98,6 +96,7 @@ public unsafe class ParameterBarAdjustments : UiAdjustments.SubTweak {
         }
     }
     
+    [TerritoryChanged]
     private void OnTerritoryChanged(ushort territoryType) {
         var territory = Service.Data.Excel.GetSheet<TerritoryType>()?.GetRow(territoryType);
         if (territory == null) return;


### PR DESCRIPTION
Added `AddonPreReceiveEvent`, `AddonPostReceiveEvent` attributes
Added `TerritoryChangedAttribute`

Added TerritoryChanged to Event Debugger
Modified Event Debugger to show header text for Framework and TerritoryChanged

I had to add another static constructor for EventSubscriber because Kind is private set

Changed Invoke to `object` to support other parameter values such as territory id

Fixed TerritoryChange delegate leak from MiniMapAdjustments