### PR TITLE
[Casting Text Visibility] add new tweak

### DIFF
--- a/Tweaks/UiAdjustment/CastingTextVisibility.cs
+++ b/Tweaks/UiAdjustment/CastingTextVisibility.cs
@@ -40,7 +40,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             public int FocusFontSize = 14;
             public int FocusBackgroundWidth = 192;
             public int FocusBackgroundHeight = 0;
-            public bool FocusAutoAdjustWidth = false;
+            public bool FocusAutoAdjustWidth = true;
 
             public Vector4 TargetTextColor = new Vector4(1);
             public Vector4 TargetEdgeColor = new Vector4(157 / 255f, 131 / 255f, 91 / 255f, 1);
@@ -48,7 +48,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             public int TargetFontSize = 14;
             public int TargetBackgroundWidth = 192;
             public int TargetBackgroundHeight = 0;
-            public bool TargetAutoAdjustWidth = false;
+            public bool TargetAutoAdjustWidth = true;
         }
 
         private void DrawConfig()

--- a/Tweaks/UiAdjustment/CastingTextVisibility.cs
+++ b/Tweaks/UiAdjustment/CastingTextVisibility.cs
@@ -1,39 +1,54 @@
-﻿using Dalamud.Interface.Components;
-using FFXIVClientStructs.FFXIV.Component.GUI;
+﻿using FFXIVClientStructs.FFXIV.Component.GUI;
 using ImGuiNET;
+using Lumina.Excel.GeneratedSheets;
 using SimpleTweaksPlugin.TweakSystem;
 using SimpleTweaksPlugin.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using System.Threading.Tasks;
+using static Dalamud.Interface.Utility.Raii.ImRaii;
 using static Lumina.Data.Parsing.Uld.NodeData;
-using static SimpleTweaksPlugin.Tweaks.UiAdjustment.TargetHP;
 
 namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
 {
-    public unsafe class CastingTextVisibility : UiAdjustments.SubTweak
+    internal unsafe class CastingTextVisibility : UiAdjustments.SubTweak
     {
-        private int _focusTargetTextNodeIndex = 16;
-        private int _targetTextNodeIndex = 44;
 
         public class Configs : TweakConfig
         {
             public bool UseCustomFocusColor = false;
             public bool UseCustomTargetColor = false;
 
-            public Vector4 CustomFocusTextColor = new Vector4(1);
-            public Vector4 CustomFocusEdgeColor = new Vector4(115 / 255f, 85 / 255f, 15 / 255f, 1);
-            public int CustomFocusFontSize = 14;
+            public Vector4 FocusTextColor = new Vector4(1);
+            public Vector4 FocusEdgeColor = new Vector4(115 / 255f, 85 / 255f, 15 / 255f, 1);
+            public Vector4 FocusBackgroundColor = new Vector4(0);
+            public int FocusFontSize = 14;
+            public int FocusBackgroundWidth = 192;
+            public int FocusBackgroundHeight = 0;
+            public bool FocusAutoAdjustWidth = false;
 
-            public Vector4 CustomTargetTextColor = new Vector4(1);
-            public Vector4 CustomTargetEdgeColor = new Vector4(157 / 255f, 131 / 255f, 91 / 255f, 1);
-            public int CustomTargetFontSize = 14;
+            public Vector4 TargetTextColor = new Vector4(1);
+            public Vector4 TargetEdgeColor = new Vector4(157 / 255f, 131 / 255f, 91 / 255f, 1);
+            public Vector4 TargetBackgroundColor = new Vector4(0);
+            public int TargetFontSize = 14;
+            public int TargetBackgroundWidth = 192;
+            public int TargetBackgroundHeight = 0;
+            public bool TargetAutoAdjustWidth = false;
         }
 
         public Configs Config { get; private set; }
+        private AtkImageNode* focusTargetImageNode = null;
+        private AtkImageNode* targetImageNode = null;
+
+        private int focusTargetDefaultNodeCount = 19;
+        private int targetDefaultNodeCount = 54;
+
+        private int focusTargetTextNodeIndex = 16;
+        private int targetTextNodeIndex = 44;
 
         protected override DrawConfigDelegate DrawConfigTree => (ref bool hasChanged) =>
         {
@@ -43,9 +58,13 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             {
                 ImGui.SetColorEditOptions(ImGuiColorEditFlags.None);
                 ImGui.Indent();
-                ImGui.ColorEdit4("Text Color##FocusTarget", ref Config.CustomFocusTextColor);
-                ImGui.ColorEdit4("Edge Color##FocusTarget", ref Config.CustomFocusEdgeColor);
-                ImGui.DragInt("Font Size##FocusTarget", ref Config.CustomFocusFontSize, 0.4f, 12, 50);
+                ImGui.ColorEdit4("Text Color##FocusTarget", ref Config.FocusTextColor);
+                ImGui.ColorEdit4("Edge Color##FocusTarget", ref Config.FocusEdgeColor);
+                ImGui.ColorEdit4("Background Color##FocusTarget", ref Config.FocusBackgroundColor);
+                ImGui.Checkbox("Auto Adjust Width##FocusTarget", ref Config.FocusAutoAdjustWidth);
+                ImGui.DragInt("Background Width##FocusTarget", ref Config.FocusBackgroundWidth, 0.6f, 90, 800);
+                ImGui.DragInt("Background Height Padding##FocusTarget", ref Config.FocusBackgroundHeight, 0.6f, -10, 30);
+                ImGui.DragInt("Font Size##FocusTarget", ref Config.FocusFontSize, 0.4f, 12, 50);
                 ImGui.Unindent();
                 ImGui.NewLine();
             }
@@ -55,9 +74,13 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             if (Config.UseCustomTargetColor)
             {
                 ImGui.Indent();
-                ImGui.ColorEdit4("Text Color##Target", ref Config.CustomTargetTextColor);
-                ImGui.ColorEdit4("Edge Color##Target", ref Config.CustomTargetEdgeColor);
-                ImGui.DragInt("Font Size##Target", ref Config.CustomTargetFontSize, 0.4f, 12, 50);
+                ImGui.ColorEdit4("Text Color##Target", ref Config.TargetTextColor);
+                ImGui.ColorEdit4("Edge Color##Target", ref Config.TargetEdgeColor);
+                ImGui.ColorEdit4("Background Color##Target", ref Config.TargetBackgroundColor);
+                ImGui.Checkbox("Auto Adjust Width##Target", ref Config.TargetAutoAdjustWidth);
+                ImGui.DragInt("Background Width##Target", ref Config.TargetBackgroundWidth, 0.6f, 90, 800);                
+                ImGui.DragInt("Background Height Padding##Target", ref Config.TargetBackgroundHeight, 0.6f, -10, 30);
+                ImGui.DragInt("Font Size##Target", ref Config.TargetFontSize, 0.4f, 12, 50);
                 ImGui.Unindent();
                 ImGui.NewLine();
             }
@@ -74,6 +97,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
         protected override void Enable()
         {
             Config = LoadConfig<Configs>() ?? new Configs();
+            CreateImageNodes();
             Common.FrameworkUpdate += FrameworkUpdate;
             base.Enable();
         }
@@ -81,8 +105,9 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
         protected override void Disable()
         {
             SaveConfig(Config);
+            DeleteImageNodes();
+            ResetTextNodes();
             Common.FrameworkUpdate -= FrameworkUpdate;
-            Update(true);
             base.Disable();
         }
 
@@ -98,100 +123,204 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             }
         }
 
-        private void Update(bool reset = false)
+        private void Update()
         {
-            if (reset)
-            {
-                ResetAll();
-                return;
-            }
+            TryDrawUi("_FocusTargetInfo", 1, focusTargetTextNodeIndex, focusTargetDefaultNodeCount,
+                Config.UseCustomFocusColor, focusTargetImageNode, Config.FocusTextColor,
+                Config.FocusEdgeColor, Config.FocusFontSize, DrawFocusTargetBackground);
 
-            //focus target
-            var focusTargetUi = Common.GetUnitBase("_FocusTargetInfo", 1);
-            if (NodeExists(focusTargetUi, _focusTargetTextNodeIndex) && focusTargetUi->IsVisible)
+            TryDrawUi("_TargetInfo", 1, targetTextNodeIndex, targetDefaultNodeCount,
+               Config.UseCustomTargetColor, targetImageNode, Config.TargetTextColor,
+               Config.TargetEdgeColor, Config.TargetFontSize, DrawTargetBackground);
+        }
+
+        unsafe delegate void DrawBackgroundAction(AtkTextNode* node);
+
+        private void TryDrawUi(string unitBaseName, int unitBaseId, int nodeIndex, int defaultNodeCount, bool useCustomColor, AtkImageNode* imageNode,
+            Vector4 textColor, Vector4 edgeColor, int fontSize, DrawBackgroundAction drawBackground)
+        {
+            var ui = Common.GetUnitBase(unitBaseName, unitBaseId);
+            if (NodeExists(ui, nodeIndex))
             {
-                var textNode = (AtkTextNode*)focusTargetUi->UldManager.NodeList[_focusTargetTextNodeIndex];
-                if (Config.UseCustomFocusColor)
+                var textNode = (AtkTextNode*)ui->UldManager.NodeList[nodeIndex];
+
+                if (ui->IsVisible && useCustomColor)
                 {
-                    AdjustTextColorsAndFontSize(textNode, Config.CustomFocusTextColor, Config.CustomFocusEdgeColor, Config.CustomFocusFontSize);
+                    TryLinkNode(ui, defaultNodeCount, imageNode);
+                    imageNode->AtkResNode.ToggleVisibility(textNode->AtkResNode.IsVisible);                    
+                    AdjustTextColorsAndFontSize(textNode, textColor, edgeColor, fontSize);
+                    drawBackground(textNode);
                 }
                 else
                 {
-                    ResetFocusTargetText(textNode);
-                }
-            }
-
-            //target
-            var targetUi = Common.GetUnitBase("_TargetInfo", 1);
-            if (NodeExists(targetUi, _targetTextNodeIndex) && targetUi->IsVisible)
-            {
-                var textNode = (AtkTextNode*)targetUi->UldManager.NodeList[_targetTextNodeIndex];
-                if (Config.UseCustomTargetColor)
-                {                    
-                    AdjustTextColorsAndFontSize(textNode, Config.CustomTargetTextColor, Config.CustomTargetEdgeColor, Config.CustomTargetFontSize);
-                }
-                else
-                {
-                    ResetTargetText(textNode);
+                    if (imageNode != null)
+                        imageNode->AtkResNode.ToggleVisibility(false);
+                    ResetText(textNode);
                 }
             }
         }
-
-        private void ResetFocusTargetText(AtkTextNode* textNode)
+        private void ResetText(AtkTextNode* textNode)
         {
-            var defaultFocusEdgeColor = new Vector4(115 / 255f, 85 / 255f, 15 / 255f, 1);
-            ResetText(textNode, defaultFocusEdgeColor);
+            var defaultEdgeColor = new Vector4(115 / 255f, 85 / 255f, 15 / 255f, 1);
+            AdjustTextColorsAndFontSize(textNode, Vector4.One, defaultEdgeColor, 14);
         }
 
-        private void ResetTargetText(AtkTextNode* textNode)
+        private void ResetTextNodes()
         {
-            var defaultTargetEdgeColor = new Vector4(157 / 255f, 131 / 255f, 91 / 255f, 1);
-            ResetText(textNode, defaultTargetEdgeColor);
+            var fui = Common.GetUnitBase("_FocusTargetInfo", 1);
+            var tui = Common.GetUnitBase("_TargetInfo", 1);
+            var ftext = (AtkTextNode*)fui->UldManager.NodeList[focusTargetTextNodeIndex];
+            var ttext = (AtkTextNode*)tui->UldManager.NodeList[targetTextNodeIndex];
+            if (fui != null)  ResetText(ftext);
+            if (tui != null)  ResetText(ttext);
         }
 
-        private void ResetText(AtkTextNode* textNode, Vector4 edgeColor) {
-            var defaultTextColor = new Vector4(1);
-            var defaultFontSize = 14;
-            AdjustTextColorsAndFontSize(textNode, defaultTextColor, edgeColor, defaultFontSize);
-
-        }
-        
-        private void ResetAll()
+        private void TryLinkNode(AtkUnitBase* ui, int defaultNodeCount, AtkImageNode* imageNode)
         {
-            var focusTargetUi = Common.GetUnitBase("_FocusTargetInfo", 1);
-            if (NodeExists(focusTargetUi, _focusTargetTextNodeIndex))
-            {
-                var textNode = (AtkTextNode*)focusTargetUi->UldManager.NodeList[_focusTargetTextNodeIndex];
-                ResetFocusTargetText(textNode);
-            }
-
-            var targetUi = Common.GetUnitBase("_TargetInfo", 1);
-            if (NodeExists(targetUi, _targetTextNodeIndex))
-            {
-                var textNode = (AtkTextNode*)targetUi->UldManager.NodeList[_targetTextNodeIndex];
-                ResetTargetText(textNode);
-            }
-        }        
+            if (ui == null || ui->RootNode == null || ui->RootNode->ChildNode == null) return;         
+            if (imageNode == null) return;
+            if (ui->UldManager.NodeListCount <= defaultNodeCount)
+                UiHelper.LinkNodeAtEnd(&imageNode->AtkResNode, ui);            
+            else
+                imageNode = (AtkImageNode*)ui->UldManager.NodeList[focusTargetDefaultNodeCount];            
+        }
 
         private void AdjustTextColorsAndFontSize(AtkTextNode* textNode, Vector4 textColor, Vector4 edgeColor, int fontSize)
         {
-            textNode->TextColor.B = (byte)(textColor.Z * 255);
             textNode->TextColor.A = (byte)(textColor.W * 255);
             textNode->TextColor.R = (byte)(textColor.X * 255);
             textNode->TextColor.G = (byte)(textColor.Y * 255);
+            textNode->TextColor.B = (byte)(textColor.Z * 255);
 
-            textNode->EdgeColor.G = (byte)(edgeColor.Y * 255);
             textNode->EdgeColor.A = (byte)(edgeColor.W * 255);
             textNode->EdgeColor.R = (byte)(edgeColor.X * 255);
+            textNode->EdgeColor.G = (byte)(edgeColor.Y * 255);
             textNode->EdgeColor.B = (byte)(edgeColor.Z * 255);
 
             textNode->FontSize = (byte)(fontSize);
-            textNode->ResizeNodeForCurrentText();
         }
 
-        /// <summary>
-        /// Check if the Unit Base and the node index exists
-        /// </summary>
+        private void DrawFocusTargetBackground(AtkTextNode* textNode)
+        {
+            //https://accessibility.psu.edu/legibility/fontsize/ idk
+            var textNodeHeight = textNode->AtkResNode.Height;
+            var imageNodeHeight = (int)(1.33 * Config.FocusFontSize + 1) + Config.FocusBackgroundHeight;
+            var imageNodeWidth = Config.FocusAutoAdjustWidth ? GetWidthFromTextLength(textNode) : Config.FocusBackgroundWidth;
+            
+            //text node height is affected by the 'Reposition Target Castbar Text' tweak.            
+            var xOffset = 0;
+            var yOffset = ((24) - textNodeHeight + (imageNodeHeight - 24)) - Config.FocusBackgroundHeight / 2;
+
+            switch (textNode->AlignmentType)
+            {
+                case AlignmentType.BottomLeft:
+                    xOffset = 6;
+                    break;
+                case AlignmentType.BottomRight:
+                    xOffset = 6 - (imageNodeWidth - 192);
+                    break;
+                case AlignmentType.Bottom:
+                    xOffset = 6 - ((imageNodeWidth - 192) + 1) / 2;
+                    break;
+            }
+
+            UiHelper.SetPosition(focusTargetImageNode, textNode->AtkResNode.X + xOffset, textNode->AtkResNode.Y - yOffset);
+            UiHelper.SetSize(focusTargetImageNode, imageNodeWidth, imageNodeHeight);
+
+            focusTargetImageNode->AtkResNode.Color.A = (byte)(Config.FocusBackgroundColor.W * 255);
+            focusTargetImageNode->AtkResNode.AddRed = (byte)(Config.FocusBackgroundColor.X * 255);
+            focusTargetImageNode->AtkResNode.AddGreen = (byte)(Config.FocusBackgroundColor.Y * 255);
+            focusTargetImageNode->AtkResNode.AddBlue = (byte)(Config.FocusBackgroundColor.Z * 255);
+        }
+      
+        private void DrawTargetBackground(AtkTextNode* textNode)
+        {
+            var textNodeHeight = textNode->AtkResNode.Height;
+            var imageNodeHeight = (int)(1.33 * Config.TargetFontSize + 1) + Config.TargetBackgroundHeight;
+            var imageNodeWidth = Config.TargetAutoAdjustWidth ? GetWidthFromTextLength(textNode) : Config.TargetBackgroundWidth;
+          
+            var xOffset = 0;
+            var yOffset = ((14) - textNodeHeight + (imageNodeHeight - 24)) - Config.TargetBackgroundHeight / 2;
+
+            switch (textNode->AlignmentType)
+            {
+                case AlignmentType.BottomLeft:
+                    xOffset = 244;
+                    break;
+                case AlignmentType.BottomRight:
+                    xOffset = 244 - ((imageNodeWidth - 192));
+                    break;
+                case AlignmentType.Bottom:
+                    xOffset = 244 - ((imageNodeWidth - 192) + 1) / 2;
+                    break;
+            }
+
+            UiHelper.SetPosition(targetImageNode, textNode->AtkResNode.X + xOffset, textNode->AtkResNode.Y - yOffset);
+            UiHelper.SetSize(targetImageNode, imageNodeWidth, imageNodeHeight);
+
+            targetImageNode->AtkResNode.Color.A = (byte)(Config.TargetBackgroundColor.W * 255);
+            targetImageNode->AtkResNode.AddRed = (byte)(Config.TargetBackgroundColor.X * 255);
+            targetImageNode->AtkResNode.AddBlue = (byte)(Config.TargetBackgroundColor.Z * 255);
+            targetImageNode->AtkResNode.AddGreen = (byte)(Config.TargetBackgroundColor.Y * 255);
+        }
+
+        //font is not monospace, so not 100% accurate
+        private int GetWidthFromTextLength(AtkTextNode* textNode)
+        {
+            var textLength = textNode->NodeText.ToString().Length;
+
+            return (int)(0.7 * textLength * textNode->FontSize + 1);
+        }
+
+        private void UnlinkImageNode(AtkUnitBase* ui, int defaultNodeCount, AtkImageNode* imageNode)
+        {
+            if (ui == null) return;
+            if (imageNode == null) return;
+            if (ui->UldManager.NodeListCount > defaultNodeCount)
+                UiHelper.UnlinkNode(&imageNode->AtkResNode, ui);
+        }
+
+        private void TryUnlinkImageNodes()
+        {
+            var focusTargetUi = Common.GetUnitBase("_FocusTargetInfo", 1);
+            UnlinkImageNode(focusTargetUi, focusTargetDefaultNodeCount, focusTargetImageNode);
+
+            var targetUi = Common.GetUnitBase("_TargetInfo", 1);
+            UnlinkImageNode(targetUi, targetDefaultNodeCount, targetImageNode);
+        }
+
+        private void CreateImageNodes()
+        {
+            CreateImageNode(out focusTargetImageNode, 0);
+            CreateImageNode(out targetImageNode, 1);
+        }
+
+        private void CreateImageNode(out AtkImageNode* node, int id)
+        {
+            node = UiHelper.MakeImageNode(CustomNodes.Get(nameof(CastingTextVisibility), id), new UiHelper.PartInfo(0, 0, 0, 0));
+            if (node == null)
+            {
+                SimpleLog.Error("Casting Text Visibiility: Failed to make background image node");
+                return;
+            }
+            node->AtkResNode.NodeFlags = NodeFlags.Enabled | NodeFlags.AnchorLeft | NodeFlags.Visible;
+            node->WrapMode = 1;
+            node->Flags = 0;
+        }
+
+        private void DeleteImageNodes()
+        {
+            TryUnlinkImageNodes();
+
+            if (focusTargetImageNode != null)
+
+                if (targetImageNode != null)
+                    UiHelper.FreeImageNode(targetImageNode);
+
+            focusTargetImageNode = null;
+            targetImageNode = null;
+        }
+
         private bool NodeExists(AtkUnitBase* unitBase, int index)
         {
             return unitBase != null && unitBase->UldManager.NodeListCount > index;

--- a/Tweaks/UiAdjustment/CastingTextVisibility.cs
+++ b/Tweaks/UiAdjustment/CastingTextVisibility.cs
@@ -90,7 +90,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
         protected override void Disable()
         {
             ResetTextNodes();
-            FreeAllNodes();            
+            FreeAllNodes();
         }
 
         [AddonPostRequestedUpdateAttribute("_TargetInfo", "_FocusTargetInfo")]
@@ -106,7 +106,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
                     break;
                 case "_TargetInfo" when addon->IsVisible:
                     UpdateAddOn(addon, targetTextNodeId, targetImageNodeid,
-                       Config.UseCustomTargetColor,Config.TargetTextColor,
+                       Config.UseCustomTargetColor, Config.TargetTextColor,
                        Config.TargetEdgeColor, Config.TargetFontSize, DrawTargetBackground);
                     break;
             }
@@ -114,15 +114,15 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
 
         unsafe delegate void DrawBackgroundAction(AtkTextNode* textNode, AtkImageNode* imageNode);
 
-        private void UpdateAddOn(AtkUnitBase* ui, uint textNodeId, uint imageNodeId,  
-            bool useCustomColor, Vector4 textColor, Vector4 edgeColor, 
+        private void UpdateAddOn(AtkUnitBase* ui, uint textNodeId, uint imageNodeId,
+            bool useCustomColor, Vector4 textColor, Vector4 edgeColor,
             int fontSize, DrawBackgroundAction drawBackground)
         {
             var textNode = Common.GetNodeByID<AtkTextNode>(&ui->UldManager, textNodeId);
             if (textNode == null) return;
-            
+
             //'_TargetInfo' text node can sometimes remain visible when targetting non-bnpcs, but parent node invis.
-            if (ui->IsVisible && useCustomColor && textNode->AtkResNode.ParentNode->IsVisible)  
+            if (ui->IsVisible && useCustomColor && textNode->AtkResNode.ParentNode->IsVisible)
             {
                 TryMakeNodes(ui, imageNodeId);
                 ToggleImageNodeVisibility(textNode->AtkResNode.IsVisible, &ui->UldManager, imageNodeId);
@@ -145,7 +145,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             imageNode->AtkResNode.ToggleVisibility(visible);
         }
 
-        private AtkImageNode* GetImageNode(AtkUldManager* uldManager, uint nodeId) => Common.GetNodeByID<AtkImageNode>(uldManager, nodeId);        
+        private AtkImageNode* GetImageNode(AtkUldManager* uldManager, uint nodeId) => Common.GetNodeByID<AtkImageNode>(uldManager, nodeId);
 
         private void AdjustTextColorsAndFontSize(AtkTextNode* textNode, Vector4 textColor, Vector4 edgeColor, int fontSize)
         {
@@ -182,12 +182,12 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             var offsetBaseX = 6;
             var offsetBaseY = 24;
 
-            DrawBackground(imageNode, textNode, offsetBaseX, offsetBaseY, Config.FocusFontSize, Config.FocusBackgroundHeight, 
+            DrawBackground(imageNode, textNode, offsetBaseX, offsetBaseY, Config.FocusFontSize, Config.FocusBackgroundHeight,
                 Config.FocusBackgroundWidth, Config.FocusAutoAdjustWidth, Config.FocusBackgroundColor);
         }
 
         private void DrawTargetBackground(AtkTextNode* textNode, AtkImageNode* imageNode)
-        {            
+        {
             var offsetBaseX = 244;
             var offsetBaseY = 14;
 
@@ -195,7 +195,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
                  Config.TargetBackgroundWidth, Config.TargetAutoAdjustWidth, Config.TargetBackgroundColor);
         }
 
-        private void DrawBackground(AtkImageNode* imageNode, AtkTextNode* textNode, int offsetBaseX, 
+        private void DrawBackground(AtkImageNode* imageNode, AtkTextNode* textNode, int offsetBaseX,
             int offsetBaseY, int fontSize, int backgroundHeight, int backgroundWidth, bool autoAdjust, Vector4 color)
         {
             //https://accessibility.psu.edu/legibility/fontsize/ idk
@@ -231,8 +231,29 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
         //font is not monospace, so not 100% accurate
         private int GetWidthFromTextLength(AtkTextNode* textNode)
         {
-            var textLength = textNode->NodeText.ToString().Length;
-            return (int)(0.7 * textLength * textNode->FontSize + 1);
+            //less accurate guestimation 
+            //var textLength = textNode->NodeText.ToString().Length;
+            //return (int)(0.7 * textLength * textNode->FontSize + 1);
+
+            var text = textNode->NodeText.ToString();
+            var length = 4;
+            foreach (var c in text) length += GetPixelWidthOfChar(c);
+            return (int)((1.0 * textNode->FontSize / 22) * length + 4);
+        }
+
+        private int GetPixelWidthOfChar(char c)
+        {
+            var defaultSpace = 4;
+            var spaceBetweenChar = 2;
+
+            //alphabetical order, eyeballed px measurement in paint, based on font size 22
+            var lowerCasePx = new[] { 13, 13, 11, 14, 12, 10, 14, 13, 4, 7, 12, 4,  20, 12, 15, 13, 14, 9,  9,  9,  12, 13, 20, 14, 13, 12 };
+            var upperCasePx = new[] { 17, 13, 14, 16, 13, 10, 15, 16, 5, 7, 14, 12, 20, 15, 19, 14, 18, 13, 12, 15, 16, 17, 23, 17, 15, 14 };
+
+            var val = (int)c;
+            if (val is >= 97 and <= 122) return spaceBetweenChar + lowerCasePx[val - 97];
+            if (val is >= 65 and <= 90) return spaceBetweenChar + upperCasePx[val - 65];
+            return defaultSpace;
         }
 
         private void TryMakeNodes(AtkUnitBase* parent, uint imageNodeId)
@@ -257,10 +278,10 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
         }
 
         private void FreeAllNodes()
-        {            
+        {
             var addonTargetInfo = Common.GetUnitBase("_TargetInfo");
             var addonFocusTargetInfo = Common.GetUnitBase("_FocusTargetInfo");
-            
+
             TryFreeImageNode(addonTargetInfo, targetImageNodeid);
             TryFreeImageNode(addonFocusTargetInfo, focusTargetImageNodeid);
         }

--- a/Tweaks/UiAdjustment/CastingTextVisibility.cs
+++ b/Tweaks/UiAdjustment/CastingTextVisibility.cs
@@ -93,7 +93,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             FreeAllNodes();            
         }
 
-        [AddonPostUpdateAttribute("_TargetInfo", "_FocusTargetInfo")]
+        [AddonPostRequestedUpdateAttribute("_TargetInfo", "_FocusTargetInfo")]
         private void OnAddonRequestedUpdate(AddonArgs args)
         {
             var addon = (AtkUnitBase*)args.Addon;

--- a/Tweaks/UiAdjustment/CastingTextVisibility.cs
+++ b/Tweaks/UiAdjustment/CastingTextVisibility.cs
@@ -1,17 +1,9 @@
 ﻿using FFXIVClientStructs.FFXIV.Component.GUI;
 using ImGuiNET;
-using Lumina.Excel.GeneratedSheets;
 using SimpleTweaksPlugin.TweakSystem;
 using SimpleTweaksPlugin.Utility;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
-using System.Reflection.Metadata.Ecma335;
-using System.Text;
-using System.Threading.Tasks;
-using static Dalamud.Interface.Utility.Raii.ImRaii;
-using static Lumina.Data.Parsing.Uld.NodeData;
 
 namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
 {
@@ -78,7 +70,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
                 ImGui.ColorEdit4("Edge Color##Target", ref Config.TargetEdgeColor);
                 ImGui.ColorEdit4("Background Color##Target", ref Config.TargetBackgroundColor);
                 ImGui.Checkbox("Auto Adjust Width##Target", ref Config.TargetAutoAdjustWidth);
-                ImGui.DragInt("Background Width##Target", ref Config.TargetBackgroundWidth, 0.6f, 90, 800);                
+                ImGui.DragInt("Background Width##Target", ref Config.TargetBackgroundWidth, 0.6f, 90, 800);
                 ImGui.DragInt("Background Height Padding##Target", ref Config.TargetBackgroundHeight, 0.6f, -10, 30);
                 ImGui.DragInt("Font Size##Target", ref Config.TargetFontSize, 0.4f, 12, 50);
                 ImGui.Unindent();
@@ -147,7 +139,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
                 if (ui->IsVisible && useCustomColor)
                 {
                     TryLinkNode(ui, defaultNodeCount, imageNode);
-                    imageNode->AtkResNode.ToggleVisibility(textNode->AtkResNode.IsVisible);                    
+                    imageNode->AtkResNode.ToggleVisibility(textNode->AtkResNode.IsVisible);
                     AdjustTextColorsAndFontSize(textNode, textColor, edgeColor, fontSize);
                     drawBackground(textNode);
                 }
@@ -171,18 +163,18 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             var tui = Common.GetUnitBase("_TargetInfo", 1);
             var ftext = (AtkTextNode*)fui->UldManager.NodeList[focusTargetTextNodeIndex];
             var ttext = (AtkTextNode*)tui->UldManager.NodeList[targetTextNodeIndex];
-            if (fui != null)  ResetText(ftext);
-            if (tui != null)  ResetText(ttext);
+            if (fui != null) ResetText(ftext);
+            if (tui != null) ResetText(ttext);
         }
 
         private void TryLinkNode(AtkUnitBase* ui, int defaultNodeCount, AtkImageNode* imageNode)
         {
-            if (ui == null || ui->RootNode == null || ui->RootNode->ChildNode == null) return;         
+            if (ui == null || ui->RootNode == null || ui->RootNode->ChildNode == null) return;
             if (imageNode == null) return;
             if (ui->UldManager.NodeListCount <= defaultNodeCount)
-                UiHelper.LinkNodeAtEnd(&imageNode->AtkResNode, ui);            
+                UiHelper.LinkNodeAtEnd(&imageNode->AtkResNode, ui);
             else
-                imageNode = (AtkImageNode*)ui->UldManager.NodeList[focusTargetDefaultNodeCount];            
+                imageNode = (AtkImageNode*)ui->UldManager.NodeList[focusTargetDefaultNodeCount];
         }
 
         private void AdjustTextColorsAndFontSize(AtkTextNode* textNode, Vector4 textColor, Vector4 edgeColor, int fontSize)
@@ -206,7 +198,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             var textNodeHeight = textNode->AtkResNode.Height;
             var imageNodeHeight = (int)(1.33 * Config.FocusFontSize + 1) + Config.FocusBackgroundHeight;
             var imageNodeWidth = Config.FocusAutoAdjustWidth ? GetWidthFromTextLength(textNode) : Config.FocusBackgroundWidth;
-            
+
             //text node height is affected by the 'Reposition Target Castbar Text' tweak.            
             var xOffset = 0;
             var yOffset = ((24) - textNodeHeight + (imageNodeHeight - 24)) - Config.FocusBackgroundHeight / 2;
@@ -232,13 +224,13 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             focusTargetImageNode->AtkResNode.AddGreen = (byte)(Config.FocusBackgroundColor.Y * 255);
             focusTargetImageNode->AtkResNode.AddBlue = (byte)(Config.FocusBackgroundColor.Z * 255);
         }
-      
+
         private void DrawTargetBackground(AtkTextNode* textNode)
         {
             var textNodeHeight = textNode->AtkResNode.Height;
             var imageNodeHeight = (int)(1.33 * Config.TargetFontSize + 1) + Config.TargetBackgroundHeight;
             var imageNodeWidth = Config.TargetAutoAdjustWidth ? GetWidthFromTextLength(textNode) : Config.TargetBackgroundWidth;
-          
+
             var xOffset = 0;
             var yOffset = ((14) - textNodeHeight + (imageNodeHeight - 24)) - Config.TargetBackgroundHeight / 2;
 
@@ -313,9 +305,9 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             TryUnlinkImageNodes();
 
             if (focusTargetImageNode != null)
-
-                if (targetImageNode != null)
-                    UiHelper.FreeImageNode(targetImageNode);
+                UiHelper.FreeImageNode(focusTargetImageNode);
+            if (targetImageNode != null)
+                UiHelper.FreeImageNode(targetImageNode);
 
             focusTargetImageNode = null;
             targetImageNode = null;

--- a/Tweaks/UiAdjustment/CastingTextVisibility.cs
+++ b/Tweaks/UiAdjustment/CastingTextVisibility.cs
@@ -135,8 +135,8 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
             if (NodeExists(ui, nodeIndex))
             {
                 var textNode = (AtkTextNode*)ui->UldManager.NodeList[nodeIndex];
-
-                if (ui->IsVisible && useCustomColor)
+                //'_TargetInfo' text node can sometimes remain visible when targetting non-bnpcs, but parent node invis.
+                if (ui->IsVisible && useCustomColor && textNode->AtkResNode.ParentNode->IsVisible)
                 {
                     TryLinkNode(ui, defaultNodeCount, imageNode);
                     imageNode->AtkResNode.ToggleVisibility(textNode->AtkResNode.IsVisible);

--- a/Tweaks/UiAdjustment/CastingTextVisibility.cs
+++ b/Tweaks/UiAdjustment/CastingTextVisibility.cs
@@ -1,0 +1,200 @@
+﻿using Dalamud.Interface.Components;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using ImGuiNET;
+using SimpleTweaksPlugin.TweakSystem;
+using SimpleTweaksPlugin.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using static Lumina.Data.Parsing.Uld.NodeData;
+using static SimpleTweaksPlugin.Tweaks.UiAdjustment.TargetHP;
+
+namespace SimpleTweaksPlugin.Tweaks.UiAdjustment
+{
+    public unsafe class CastingTextVisibility : UiAdjustments.SubTweak
+    {
+        private int _focusTargetTextNodeIndex = 16;
+        private int _targetTextNodeIndex = 44;
+
+        public class Configs : TweakConfig
+        {
+            public bool UseCustomFocusColor = false;
+            public bool UseCustomTargetColor = false;
+
+            public Vector4 CustomFocusTextColor = new Vector4(1);
+            public Vector4 CustomFocusEdgeColor = new Vector4(115 / 255f, 85 / 255f, 15 / 255f, 1);
+            public int CustomFocusFontSize = 14;
+
+            public Vector4 CustomTargetTextColor = new Vector4(1);
+            public Vector4 CustomTargetEdgeColor = new Vector4(157 / 255f, 131 / 255f, 91 / 255f, 1);
+            public int CustomTargetFontSize = 14;
+        }
+
+        public Configs Config { get; private set; }
+
+        protected override DrawConfigDelegate DrawConfigTree => (ref bool hasChanged) =>
+        {
+            ImGui.Checkbox("Focus Target", ref Config.UseCustomFocusColor);
+
+            if (Config.UseCustomFocusColor)
+            {
+                ImGui.SetColorEditOptions(ImGuiColorEditFlags.None);
+                ImGui.Indent();
+                ImGui.ColorEdit4("Text Color##FocusTarget", ref Config.CustomFocusTextColor);
+                ImGui.ColorEdit4("Edge Color##FocusTarget", ref Config.CustomFocusEdgeColor);
+                ImGui.DragInt("Font Size##FocusTarget", ref Config.CustomFocusFontSize, 0.4f, 12, 50);
+                ImGui.Unindent();
+                ImGui.NewLine();
+            }
+
+            ImGui.Checkbox("Target", ref Config.UseCustomTargetColor);
+
+            if (Config.UseCustomTargetColor)
+            {
+                ImGui.Indent();
+                ImGui.ColorEdit4("Text Color##Target", ref Config.CustomTargetTextColor);
+                ImGui.ColorEdit4("Edge Color##Target", ref Config.CustomTargetEdgeColor);
+                ImGui.DragInt("Font Size##Target", ref Config.CustomTargetFontSize, 0.4f, 12, 50);
+                ImGui.Unindent();
+                ImGui.NewLine();
+            }
+        };
+
+        public override string Name => "Casting Text Visibility";
+        public override string Description => "Change casting text color and font size.";
+
+        public override void Setup()
+        {
+            base.Setup();
+        }
+
+        protected override void Enable()
+        {
+            Config = LoadConfig<Configs>() ?? new Configs();
+            Common.FrameworkUpdate += FrameworkUpdate;
+            base.Enable();
+        }
+
+        protected override void Disable()
+        {
+            SaveConfig(Config);
+            Common.FrameworkUpdate -= FrameworkUpdate;
+            Update(true);
+            base.Disable();
+        }
+
+        private void FrameworkUpdate()
+        {
+            try
+            {
+                Update();
+            }
+            catch (Exception ex)
+            {
+                SimpleLog.Error(ex);
+            }
+        }
+
+        private void Update(bool reset = false)
+        {
+            if (reset)
+            {
+                ResetAll();
+                return;
+            }
+
+            //focus target
+            var focusTargetUi = Common.GetUnitBase("_FocusTargetInfo", 1);
+            if (NodeExists(focusTargetUi, _focusTargetTextNodeIndex) && focusTargetUi->IsVisible)
+            {
+                var textNode = (AtkTextNode*)focusTargetUi->UldManager.NodeList[_focusTargetTextNodeIndex];
+                if (Config.UseCustomFocusColor)
+                {
+                    AdjustTextColorsAndFontSize(textNode, Config.CustomFocusTextColor, Config.CustomFocusEdgeColor, Config.CustomFocusFontSize);
+                }
+                else
+                {
+                    ResetFocusTargetText(textNode);
+                }
+            }
+
+            //target
+            var targetUi = Common.GetUnitBase("_TargetInfo", 1);
+            if (NodeExists(targetUi, _targetTextNodeIndex) && targetUi->IsVisible)
+            {
+                var textNode = (AtkTextNode*)targetUi->UldManager.NodeList[_targetTextNodeIndex];
+                if (Config.UseCustomTargetColor)
+                {                    
+                    AdjustTextColorsAndFontSize(textNode, Config.CustomTargetTextColor, Config.CustomTargetEdgeColor, Config.CustomTargetFontSize);
+                }
+                else
+                {
+                    ResetTargetText(textNode);
+                }
+            }
+        }
+
+        private void ResetFocusTargetText(AtkTextNode* textNode)
+        {
+            var defaultFocusEdgeColor = new Vector4(115 / 255f, 85 / 255f, 15 / 255f, 1);
+            ResetText(textNode, defaultFocusEdgeColor);
+        }
+
+        private void ResetTargetText(AtkTextNode* textNode)
+        {
+            var defaultTargetEdgeColor = new Vector4(157 / 255f, 131 / 255f, 91 / 255f, 1);
+            ResetText(textNode, defaultTargetEdgeColor);
+        }
+
+        private void ResetText(AtkTextNode* textNode, Vector4 edgeColor) {
+            var defaultTextColor = new Vector4(1);
+            var defaultFontSize = 14;
+            AdjustTextColorsAndFontSize(textNode, defaultTextColor, edgeColor, defaultFontSize);
+
+        }
+        
+        private void ResetAll()
+        {
+            var focusTargetUi = Common.GetUnitBase("_FocusTargetInfo", 1);
+            if (NodeExists(focusTargetUi, _focusTargetTextNodeIndex))
+            {
+                var textNode = (AtkTextNode*)focusTargetUi->UldManager.NodeList[_focusTargetTextNodeIndex];
+                ResetFocusTargetText(textNode);
+            }
+
+            var targetUi = Common.GetUnitBase("_TargetInfo", 1);
+            if (NodeExists(targetUi, _targetTextNodeIndex))
+            {
+                var textNode = (AtkTextNode*)targetUi->UldManager.NodeList[_targetTextNodeIndex];
+                ResetTargetText(textNode);
+            }
+        }        
+
+        private void AdjustTextColorsAndFontSize(AtkTextNode* textNode, Vector4 textColor, Vector4 edgeColor, int fontSize)
+        {
+            textNode->TextColor.B = (byte)(textColor.Z * 255);
+            textNode->TextColor.A = (byte)(textColor.W * 255);
+            textNode->TextColor.R = (byte)(textColor.X * 255);
+            textNode->TextColor.G = (byte)(textColor.Y * 255);
+
+            textNode->EdgeColor.G = (byte)(edgeColor.Y * 255);
+            textNode->EdgeColor.A = (byte)(edgeColor.W * 255);
+            textNode->EdgeColor.R = (byte)(edgeColor.X * 255);
+            textNode->EdgeColor.B = (byte)(edgeColor.Z * 255);
+
+            textNode->FontSize = (byte)(fontSize);
+            textNode->ResizeNodeForCurrentText();
+        }
+
+        /// <summary>
+        /// Check if the Unit Base and the node index exists
+        /// </summary>
+        private bool NodeExists(AtkUnitBase* unitBase, int index)
+        {
+            return unitBase != null && unitBase->UldManager.NodeListCount > index;
+        }
+    }
+}


### PR DESCRIPTION
Allows the user to change target + focus target casting text colour and font size. (I have bad eyesight)

![image](https://github.com/Caraxi/SimpleTweaksPlugin/assets/70348218/bb25de5e-7d38-41b7-b3a2-5e5afb1e3e9a)
![image](https://github.com/Caraxi/SimpleTweaksPlugin/assets/70348218/c8fc0a3c-bb69-4abd-98c3-d26767ad2212)

would have liked to add a thicker edge or background but I couldn't get it to work :(

I based it off of TargetHp, so sorry if something's off.