### PR TITLE
[`ImprovedCraftingLog`] Fix Framework Update event handler unsubscribing

### DIFF
--- a/Tweaks/UiAdjustment/ImprovedCraftingLog.cs
+++ b/Tweaks/UiAdjustment/ImprovedCraftingLog.cs
@@ -124,13 +124,17 @@ public unsafe class ImprovedCraftingLog : Tweak {
     }
 
     private void ForceUpdateFramework() {
-        if (removeFrameworkUpdateEventStopwatch.ElapsedMilliseconds > 5000) Common.FrameworkUpdate -= ForceUpdateFramework;
-        ForceUpdate();
+        if (removeFrameworkUpdateEventStopwatch.ElapsedMilliseconds > 5000)
+        {
+            Common.FrameworkUpdate -= ForceUpdateFramework;
+            removeFrameworkUpdateEventStopwatch.Stop();
+        }
         if (standingUp == false || Service.ClientState.LocalPlayer == null) return;
         var localPlayer = (Character*) Service.ClientState.LocalPlayer.Address;
         if (localPlayer->Mode != Character.CharacterModes.Crafting) {
             standingUp = false;
         }
+        ForceUpdate();
     }
     
     public enum CraftReadyState {
@@ -193,6 +197,7 @@ public unsafe class ImprovedCraftingLog : Tweak {
             agent->OpenRecipeByRecipeId(selectedRecipeId);
 
             standingUp = true;
+            removeFrameworkUpdateEventStopwatch.Restart();
             Common.FrameworkUpdate += ForceUpdateFramework;
         }
     }

--- a/Tweaks/UiAdjustment/ImprovedCraftingLog.cs
+++ b/Tweaks/UiAdjustment/ImprovedCraftingLog.cs
@@ -124,8 +124,7 @@ public unsafe class ImprovedCraftingLog : Tweak {
     }
 
     private void ForceUpdateFramework() {
-        if (removeFrameworkUpdateEventStopwatch.ElapsedMilliseconds > 5000)
-        {
+        if (removeFrameworkUpdateEventStopwatch.ElapsedMilliseconds > 5000) {
             Common.FrameworkUpdate -= ForceUpdateFramework;
             removeFrameworkUpdateEventStopwatch.Stop();
         }


### PR DESCRIPTION
Restart the timer when changing jobs to allow the framework update event to unsubscribe.

Also reordered the method to force update after checking states rather than before.