### PR TITLE
[`ColorDutyRouletteNames`] Fix config UI not being displayed

### DIFF
--- a/Tweaks/UiAdjustment/ColoredDutyRoulette.cs
+++ b/Tweaks/UiAdjustment/ColoredDutyRoulette.cs
@@ -77,6 +77,7 @@ public unsafe partial class ColoredDutyRoulette : UiAdjustments.SubTweak {
             var filteredName = Alphanumeric().Replace(entry.Category.ToString().ToLower(), string.Empty);
             rouletteIdDictionary.TryAdd(filteredName, entry.RowId);
         }
+        base.Setup();
     }
 
     protected override void Disable() {


### PR DESCRIPTION
This tweak was updated to use `DrawConfig`, but its `Setup` method doesn't call `base.Setup()`, so `AttemptDrawConfigSetup()` is never called. As a result, the config UI doesn't draw. I just changed `Setup` to call the base method, which fixes this issue.