### PR TITLE
[`GlamItemNames`] New Tweak

### DIFF
--- a/Tweaks/Tooltips/GlamItemNames.cs
+++ b/Tweaks/Tooltips/GlamItemNames.cs
@@ -1,0 +1,132 @@
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
+using FFXIVClientStructs.FFXIV.Client.System.Memory;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using SimpleTweaksPlugin.TweakSystem;
+using SimpleTweaksPlugin.Utility;
+
+namespace SimpleTweaksPlugin.Tweaks.Tooltips;
+
+[TweakAuthor("Enriath")]
+[TweakName("Show Glamour in Item Name")]
+[TweakDescription("Displays the glamoured item name underneath the real item name.")]
+public unsafe class GlamItemNames : TooltipTweaks.SubTweak {
+    private const uint ITEM_TOOLTIP_NAME_NODE_ID = 32;
+    private const byte NAME_DEFAULT_FONT_SIZE = 14;
+
+    private string last = "";
+
+    public override void OnGenerateItemTooltip(NumberArrayData* numberArrayData, StringArrayData* stringArrayData) {
+        if (Service.ClientState.LocalPlayer == null) return;
+        if (Service.GameGui.HoveredItem > uint.MaxValue) return;
+        AtkUnitBase* unitBase = Common.GetUnitBase("ItemDetail");
+        if (unitBase == null) return;
+
+        AtkTextNode* replacementNameNode = Common.GetNodeByID<AtkTextNode>(&unitBase->UldManager, CustomNodes.GlamNameReplacementText, NodeType.Text);
+
+        // Hide the replacement widget and show the original widget, so that if we don't need to add a glam name it'll be back to vanilla
+        if (replacementNameNode != null) replacementNameNode->AtkResNode.ToggleVisibility(false);
+
+        AtkResNode* vanillaNameNode = unitBase->GetNodeById(ITEM_TOOLTIP_NAME_NODE_ID);
+        if (vanillaNameNode == null) return;
+        vanillaNameNode->ToggleVisibility(true);
+
+        SeString glamName = GetTooltipString(stringArrayData, TooltipTweaks.ItemTooltipField.GlamourName);
+        
+        // We don't need to do anything the item isn't / cannot be glamoured
+        if (glamName == null) return;
+
+        SeString normalName = GetTooltipString(stringArrayData, TooltipTweaks.ItemTooltipField.ItemName);
+        
+        normalName.Append(NewLinePayload.Payload);
+        normalName.Append(glamName);
+
+        if (replacementNameNode == null) {
+            replacementNameNode = CreateReplacementTextNode(vanillaNameNode);
+            last = "";
+        }
+
+        if (normalName.TextValue != last) {
+            last = normalName.TextValue;
+            ushort w, h;
+            byte fs = NAME_DEFAULT_FONT_SIZE;
+            // Shrink the font until we get to 2 lines
+            // Also reset the size back to default if another tooltip's name shrank it
+            do {
+                replacementNameNode->FontSize = fs;
+                // Set the text each time we change the font to update the drawn size of the text
+                replacementNameNode->SetText(normalName.Encode());
+                replacementNameNode->GetTextDrawSize(&w, &h);
+                fs -= 1;
+            } while(h > 35);
+        }
+
+        vanillaNameNode->ToggleVisibility(false); 
+        replacementNameNode->AtkResNode.ToggleVisibility(true);
+        unitBase->UldManager.UpdateDrawNodeList(); 
+    }
+
+    private AtkTextNode* CreateReplacementTextNode(AtkResNode* replacedNode) {
+        AtkTextNode* node = IMemorySpace.GetUISpace()->Create<AtkTextNode>();
+        if (node == null) return null;
+        node->AtkResNode.Type = NodeType.Text;
+        node->AtkResNode.NodeID = CustomNodes.GlamNameReplacementText;
+
+        node->AtkResNode.SetWidth(replacedNode->GetWidth());
+        node->AtkResNode.SetHeight(replacedNode->GetHeight());
+        node->AtkResNode.SetPositionFloat(replacedNode->GetX(), replacedNode->GetY());
+        node->FontSize = NAME_DEFAULT_FONT_SIZE;
+        node->TextFlags = replacedNode->GetAsAtkTextNode()->TextFlags;
+        node->TextFlags2 = replacedNode->GetAsAtkTextNode()->TextFlags2;
+        node->AlignmentFontType = replacedNode->GetAsAtkTextNode()->AlignmentFontType;
+        node->LineSpacing = replacedNode->GetAsAtkTextNode()->LineSpacing;
+        node->SetAlignment(replacedNode->GetAsAtkTextNode()->AlignmentType);
+
+        node->TextColor.R = replacedNode->GetAsAtkTextNode()->TextColor.R;
+        node->TextColor.G = replacedNode->GetAsAtkTextNode()->TextColor.G;
+        node->TextColor.B = replacedNode->GetAsAtkTextNode()->TextColor.B;
+        node->TextColor.A = replacedNode->GetAsAtkTextNode()->TextColor.A;
+
+        node->EdgeColor.R = replacedNode->GetAsAtkTextNode()->EdgeColor.R;
+        node->EdgeColor.G = replacedNode->GetAsAtkTextNode()->EdgeColor.G;
+        node->EdgeColor.B = replacedNode->GetAsAtkTextNode()->EdgeColor.B;
+        node->EdgeColor.A = replacedNode->GetAsAtkTextNode()->EdgeColor.A;
+
+        node->BackgroundColor.R = replacedNode->GetAsAtkTextNode()->BackgroundColor.R;
+        node->BackgroundColor.G = replacedNode->GetAsAtkTextNode()->BackgroundColor.G;
+        node->BackgroundColor.B = replacedNode->GetAsAtkTextNode()->BackgroundColor.B;
+        node->BackgroundColor.A = replacedNode->GetAsAtkTextNode()->BackgroundColor.A;
+
+        node->AtkResNode.ParentNode = replacedNode->ParentNode;
+        AtkResNode* prev = replacedNode->PrevSiblingNode;
+        replacedNode->PrevSiblingNode = (AtkResNode*)node;
+        if (prev != null) prev->NextSiblingNode = (AtkResNode*)node;
+
+        node->AtkResNode.PrevSiblingNode = prev;
+        node->AtkResNode.NextSiblingNode = replacedNode;
+
+        return node;
+    }
+
+    protected override void Disable() {        
+        AtkUnitBase* unitBase = Common.GetUnitBase("ItemDetail");
+        if (unitBase != null) {
+            AtkResNode* textNode = Common.GetNodeByID(&unitBase->UldManager, CustomNodes.GlamNameReplacementText, NodeType.Text);
+            if (textNode != null) {
+                if (textNode->PrevSiblingNode != null)
+                    textNode->PrevSiblingNode->NextSiblingNode = textNode->NextSiblingNode;
+                if (textNode->NextSiblingNode != null)
+                    textNode->NextSiblingNode->PrevSiblingNode = textNode->PrevSiblingNode;
+                unitBase->UldManager.UpdateDrawNodeList();
+                textNode->Destroy(true);
+            }
+
+            AtkResNode* original = unitBase->GetNodeById(ITEM_TOOLTIP_NAME_NODE_ID);
+            if (original != null) {
+                original->ToggleVisibility(true);
+            }
+        }
+        
+        base.Disable();
+    }
+}

--- a/Tweaks/Tooltips/GlamItemNames.cs
+++ b/Tweaks/Tooltips/GlamItemNames.cs
@@ -14,6 +14,8 @@ public unsafe class GlamItemNames : TooltipTweaks.SubTweak {
     private const uint ITEM_TOOLTIP_NAME_NODE_ID = 32;
     private const byte NAME_DEFAULT_FONT_SIZE = 14;
 
+    private const string GLAM_NAME_REPLACEMENT_TEXT = "GlamNameReplacementText";
+
     private string last = "";
 
     public override void OnGenerateItemTooltip(NumberArrayData* numberArrayData, StringArrayData* stringArrayData) {
@@ -22,7 +24,7 @@ public unsafe class GlamItemNames : TooltipTweaks.SubTweak {
         AtkUnitBase* unitBase = Common.GetUnitBase("ItemDetail");
         if (unitBase == null) return;
 
-        AtkTextNode* replacementNameNode = Common.GetNodeByID<AtkTextNode>(&unitBase->UldManager, CustomNodes.GlamNameReplacementText, NodeType.Text);
+        AtkTextNode* replacementNameNode = Common.GetNodeByID<AtkTextNode>(&unitBase->UldManager, CustomNodes.Get(this, GLAM_NAME_REPLACEMENT_TEXT), NodeType.Text);
 
         // Hide the replacement widget and show the original widget, so that if we don't need to add a glam name it'll be back to vanilla
         if (replacementNameNode != null) replacementNameNode->AtkResNode.ToggleVisibility(false);
@@ -70,7 +72,7 @@ public unsafe class GlamItemNames : TooltipTweaks.SubTweak {
         AtkTextNode* node = IMemorySpace.GetUISpace()->Create<AtkTextNode>();
         if (node == null) return null;
         node->AtkResNode.Type = NodeType.Text;
-        node->AtkResNode.NodeID = CustomNodes.GlamNameReplacementText;
+        node->AtkResNode.NodeID = CustomNodes.Get(this, GLAM_NAME_REPLACEMENT_TEXT);
 
         node->AtkResNode.SetWidth(replacedNode->GetWidth());
         node->AtkResNode.SetHeight(replacedNode->GetHeight());
@@ -111,7 +113,7 @@ public unsafe class GlamItemNames : TooltipTweaks.SubTweak {
     protected override void Disable() {        
         AtkUnitBase* unitBase = Common.GetUnitBase("ItemDetail");
         if (unitBase != null) {
-            AtkResNode* textNode = Common.GetNodeByID(&unitBase->UldManager, CustomNodes.GlamNameReplacementText, NodeType.Text);
+            AtkResNode* textNode = Common.GetNodeByID(&unitBase->UldManager, CustomNodes.Get(this, GLAM_NAME_REPLACEMENT_TEXT), NodeType.Text);
             if (textNode != null) {
                 if (textNode->PrevSiblingNode != null)
                     textNode->PrevSiblingNode->NextSiblingNode = textNode->NextSiblingNode;

--- a/Utility/CustomNodes.cs
+++ b/Utility/CustomNodes.cs
@@ -44,6 +44,5 @@ public static class CustomNodes {
         AdditionalInfo =       SimpleTweaksNodeBase + 11,
         CraftingGhostBar =     SimpleTweaksNodeBase + 12,
         CraftingGhostText =    SimpleTweaksNodeBase + 13,
-        GlamNameReplacementText = SimpleTweaksNodeBase + 14,
         SimpleTweaksNodeBase = 0x53540000;
 }

--- a/Utility/CustomNodes.cs
+++ b/Utility/CustomNodes.cs
@@ -44,5 +44,6 @@ public static class CustomNodes {
         AdditionalInfo =       SimpleTweaksNodeBase + 11,
         CraftingGhostBar =     SimpleTweaksNodeBase + 12,
         CraftingGhostText =    SimpleTweaksNodeBase + 13,
+        GlamNameReplacementText = SimpleTweaksNodeBase + 14,
         SimpleTweaksNodeBase = 0x53540000;
 }


### PR DESCRIPTION
A tweak to show both the item's name and the glamour name at the same time in tooltips, instead of fading between the two. It's a tweak I've been wanting for a while.

The game has roughly enough space for 2 lines of text in the tooltips, which it does use. Going up to 3 lines was inconsistent in how the text looked, so I aim to get to two. For most items, it looks absolutely fine, though for very long names it's a *little* annoying? I've been thinking about how I could make it better without having to mess with the entire tooltip (and likely break other tweaks and plugins), but it's so narrow I don't think it'll matter much.

The node creation code is heavily based off of the AdditionalItemInfo tweak.
This is my first real time writing C# (though I have experience with other languages), and my first time working with Dalamud, so I hope I've done everything right (there wasn't a contributing guide that I could find, so I've been trying to copy styles from elsewhere). I've been testing it locally for a while, and it's been working very nicely.

A normal item with a normal glamour, no font size changes
![image](https://github.com/Caraxi/SimpleTweaksPlugin/assets/2979691/462cea69-335c-4246-be26-b46c737ef856)

The item I use for one of my glams that made me realise there was an issue with multiple lines. The font size is very slightly smaller to compensate for the extra length of "Augmented Ironworks Doublet of Casting"
![image](https://github.com/Caraxi/SimpleTweaksPlugin/assets/2979691/e00df668-6b62-4905-9f83-89480ee37f92)

An example to show how it works with items of different rarity: the colours are kept!
![image](https://github.com/Caraxi/SimpleTweaksPlugin/assets/2979691/2fe727f1-133f-45e7-8084-d3a1eb753e2c)
![image](https://github.com/Caraxi/SimpleTweaksPlugin/assets/2979691/093da8e2-a915-4d9c-b7a8-75d3c1e636d3)

What may be the longest equipable item name in the game (definitely by string length, not sure about text width though), forced onto the item for debug purposes. This is (probably) the smallest the text will go unless SE add some exceptionally long item names in the future.
![image](https://github.com/Caraxi/SimpleTweaksPlugin/assets/2979691/f14f030c-be53-4386-bea0-ee1a226a3e4b)

