### PR TITLE
[`EmoteLogServerBarEntry`] New Tweak

### DIFF
--- a/Service.cs
+++ b/Service.cs
@@ -6,11 +6,10 @@ using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 
-namespace SimpleTweaksPlugin;
+namespace SimpleTweaksPlugin; 
 
 [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]
-public class Service
-{
+public class Service {
     [PluginService] public static DalamudPluginInterface PluginInterface { get; private set; }
     [PluginService] public static IChatGui Chat { get; private set; }
     [PluginService] public static IClientState ClientState { get; private set; }

--- a/Service.cs
+++ b/Service.cs
@@ -6,10 +6,11 @@ using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 
-namespace SimpleTweaksPlugin; 
+namespace SimpleTweaksPlugin;
 
 [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]
-public class Service {
+public class Service
+{
     [PluginService] public static DalamudPluginInterface PluginInterface { get; private set; }
     [PluginService] public static IChatGui Chat { get; private set; }
     [PluginService] public static IClientState ClientState { get; private set; }
@@ -26,4 +27,5 @@ public class Service {
     [PluginService] public static IGameConfig GameConfig { get; private set; }
     [PluginService] public static ITextureProvider TextureProvider { get; private set; }
     [PluginService] public static IAddonLifecycle AddonLifecycle { get; private set; }
+    [PluginService] public static IDtrBar DtrBar { get; private set; }
 }

--- a/SimpleTweaksPlugin.cs
+++ b/SimpleTweaksPlugin.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Plugin;
+using Dalamud.Plugin;
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
@@ -45,8 +45,9 @@ namespace SimpleTweaksPlugin {
         public readonly DebugWindow DebugWindow = new DebugWindow();
         public readonly WindowSystem WindowSystem = new WindowSystem("SimpleTweaksPlugin");
         public readonly Changelog ChangelogWindow = new();
-        
-        
+
+        public IDtrBar DtrBar { get; private set; }
+
         internal CultureInfo Culture {
             get {
                 if (setCulture != null) return setCulture;
@@ -87,7 +88,7 @@ namespace SimpleTweaksPlugin {
 
         public int UpdateFrom = -1;
 
-        public SimpleTweaksPlugin(DalamudPluginInterface pluginInterface) {
+        public SimpleTweaksPlugin(DalamudPluginInterface pluginInterface, IDtrBar dtrBar) {
             Plugin = this;
             pluginInterface.Create<Service>();
             pluginInterface.Create<SimpleLog>();
@@ -95,7 +96,7 @@ namespace SimpleTweaksPlugin {
             
             this.PluginConfig = (SimpleTweaksPluginConfig)Service.PluginInterface.GetPluginConfig() ?? new SimpleTweaksPluginConfig();
             this.PluginConfig.Init(this);
-            
+            this.DtrBar = dtrBar;
 #if DEBUG
             SimpleLog.SetupBuildPath();
             Task.Run(() => {

--- a/SimpleTweaksPlugin.cs
+++ b/SimpleTweaksPlugin.cs
@@ -1,4 +1,4 @@
-using Dalamud.Plugin;
+﻿using Dalamud.Plugin;
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
@@ -45,9 +45,8 @@ namespace SimpleTweaksPlugin {
         public readonly DebugWindow DebugWindow = new DebugWindow();
         public readonly WindowSystem WindowSystem = new WindowSystem("SimpleTweaksPlugin");
         public readonly Changelog ChangelogWindow = new();
-
-        public IDtrBar DtrBar { get; private set; }
-
+        
+        
         internal CultureInfo Culture {
             get {
                 if (setCulture != null) return setCulture;
@@ -88,7 +87,7 @@ namespace SimpleTweaksPlugin {
 
         public int UpdateFrom = -1;
 
-        public SimpleTweaksPlugin(DalamudPluginInterface pluginInterface, IDtrBar dtrBar) {
+        public SimpleTweaksPlugin(DalamudPluginInterface pluginInterface) {
             Plugin = this;
             pluginInterface.Create<Service>();
             pluginInterface.Create<SimpleLog>();
@@ -96,7 +95,7 @@ namespace SimpleTweaksPlugin {
             
             this.PluginConfig = (SimpleTweaksPluginConfig)Service.PluginInterface.GetPluginConfig() ?? new SimpleTweaksPluginConfig();
             this.PluginConfig.Init(this);
-            this.DtrBar = dtrBar;
+            
 #if DEBUG
             SimpleLog.SetupBuildPath();
             Task.Run(() => {

--- a/Tweaks/EmoteLogServerBarEntry.cs
+++ b/Tweaks/EmoteLogServerBarEntry.cs
@@ -1,0 +1,57 @@
+﻿using Dalamud.Game.Config;
+using Dalamud.Game.Gui.Dtr;
+using SimpleTweaksPlugin.TweakSystem;
+
+namespace SimpleTweaksPlugin;
+
+[TweakAuthor("Sythiri")]
+public unsafe class EmoteLogServerBarEntry : Tweak
+{
+    public override string Name => "Emote Log Status in Server Bar";
+    public override string Description => "Show the emote log status in the server bar.";
+    private DtrBarEntry _emoteLogBarEntry;
+
+    protected override void Enable()
+    {
+        _emoteLogBarEntry = Plugin.DtrBar.Get("EmoteLog");
+        _emoteLogBarEntry.OnClick += DtrEntryClicked;
+        Service.GameConfig.UiConfigChanged += UiConfigChanged;
+        SetDtrEntryText();
+        base.Enable();
+    }
+
+    protected override void Disable()
+    {
+        _emoteLogBarEntry.OnClick -= DtrEntryClicked;
+        Service.GameConfig.UiConfigChanged -= UiConfigChanged;
+        Plugin.DtrBar.Remove("EmoteLog");
+        _emoteLogBarEntry.Shown = false;
+        base.Disable();
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+    }
+
+    private void DtrEntryClicked()
+    {
+        var value = Service.GameConfig.UiConfig.GetBool("EmoteTextType");
+        Service.GameConfig.UiConfig.Set("EmoteTextType", !value);
+    }
+
+    private void UiConfigChanged(object sender, ConfigChangeEvent e)
+    {
+        if ((UiConfigOption)e.Option == UiConfigOption.EmoteTextType)
+        {
+            SetDtrEntryText();
+        }
+    }
+
+    private void SetDtrEntryText()
+    {
+        string text = Service.GameConfig.UiConfig.GetBool("EmoteTextType") ? "" : "";
+        _emoteLogBarEntry.Text = $"Emotes: {text}";
+    }
+
+}

--- a/Tweaks/EmoteLogServerBarEntry.cs
+++ b/Tweaks/EmoteLogServerBarEntry.cs
@@ -7,7 +7,8 @@ namespace SimpleTweaksPlugin;
 [TweakAuthor("Sythiri")]
 [TweakName("Emote Log Status in Server Bar")]
 [TweakDescription("Show the emote log status in the server bar.")]
-public unsafe class EmoteLogServerBarEntry : Tweak
+[TweakReleaseVersion(UnreleasedVersion)]
+public class EmoteLogServerBarEntry : Tweak
 {
     private DtrBarEntry _emoteLogBarEntry;
 

--- a/Tweaks/EmoteLogServerBarEntry.cs
+++ b/Tweaks/EmoteLogServerBarEntry.cs
@@ -5,15 +5,15 @@ using SimpleTweaksPlugin.TweakSystem;
 namespace SimpleTweaksPlugin;
 
 [TweakAuthor("Sythiri")]
+[TweakName("Emote Log Status in Server Bar")]
+[TweakDescription("Show the emote log status in the server bar.")]
 public unsafe class EmoteLogServerBarEntry : Tweak
 {
-    public override string Name => "Emote Log Status in Server Bar";
-    public override string Description => "Show the emote log status in the server bar.";
     private DtrBarEntry _emoteLogBarEntry;
 
     protected override void Enable()
     {
-        _emoteLogBarEntry = Plugin.DtrBar.Get("EmoteLog");
+        _emoteLogBarEntry = Service.DtrBar.Get("EmoteLog");
         _emoteLogBarEntry.OnClick += DtrEntryClicked;
         Service.GameConfig.UiConfigChanged += UiConfigChanged;
         SetDtrEntryText();
@@ -24,14 +24,9 @@ public unsafe class EmoteLogServerBarEntry : Tweak
     {
         _emoteLogBarEntry.OnClick -= DtrEntryClicked;
         Service.GameConfig.UiConfigChanged -= UiConfigChanged;
-        Plugin.DtrBar.Remove("EmoteLog");
+        Service.DtrBar.Remove("EmoteLog");
         _emoteLogBarEntry.Shown = false;
         base.Disable();
-    }
-
-    public override void Dispose()
-    {
-        base.Dispose();
     }
 
     private void DtrEntryClicked()


### PR DESCRIPTION
Added a new Tweak that tracks the status of the Emote Log in the server bar. This will respond to changes via either the Emotes UI panel, or the slash command /emotelog. Clicking on the entry in the bar will also toggle it.

Emote log off:
![image](https://github.com/Caraxi/SimpleTweaksPlugin/assets/5260338/ec30a67d-5b31-4174-8580-40f669a6fb22)

Emote log on:
![image](https://github.com/Caraxi/SimpleTweaksPlugin/assets/5260338/40ca0464-8661-4e52-8a1b-d80dbf054a86)
