### PR TITLE
[`Set Option Command`] Add `*NameTitle` commands for changing `NamePlateNameTitleType*`

### DIFF
--- a/Tweaks/SetOptionCommand.cs
+++ b/Tweaks/SetOptionCommand.cs
@@ -143,6 +143,12 @@ public unsafe class SetOptionCommand : CommandTweak {
         new OptionDefinition<uint>("OtherPlayerDisplayName", "NamePlateDispTypeOther", OptionGroup.UiConfig, ValueType.NamePlateDisplay, "opcdn") { AllowToggle = true },
         new OptionDefinition<uint>("FriendDisplayName", "NamePlateDispTypeFriend", OptionGroup.UiConfig, ValueType.NamePlateDisplay, "fdn") { AllowToggle = true },
         
+        new OptionDefinition<uint>("SelfNameTitle", "NamePlateNameTitleTypeSelf", OptionGroup.UiConfig, ValueType.Boolean, "snt") { AllowToggle = true },
+        new OptionDefinition<uint>("PartyNameTitle", "NamePlateNameTitleTypeParty", OptionGroup.UiConfig, ValueType.Boolean, "pnt") { AllowToggle = true },
+        new OptionDefinition<uint>("AllianceNameTitle", "NamePlateNameTitleTypeAlliance", OptionGroup.UiConfig, ValueType.Boolean, "ant") { AllowToggle = true },
+        new OptionDefinition<uint>("OtherNameTitle", "NamePlateNameTitleTypeOther", OptionGroup.UiConfig, ValueType.Boolean, "ont") { AllowToggle = true },
+        new OptionDefinition<uint>("FriendNameTitle", "NamePlateNameTitleTypeFriend", OptionGroup.UiConfig, ValueType.Boolean, "fnt") { AllowToggle = true },
+        
         new OptionDefinition<uint>("CutsceneAudioLanguage", "CutsceneMovieVoice", OptionGroup.System, ValueType.AudioLanguage, "cl"),
         new OptionDefinition<uint>("DisplayNameSize", "NamePlateDispSize", OptionGroup.UiConfig, () => {
             return (


### PR DESCRIPTION
Allows changing the title display for self, party members, alliance members, other players, and friends. I tried to use a similar pattern for the command names and aliases as `SelfNameTitle` etc, but I'm happy to use some other format if you'd prefer that.