### PR TITLE
[`FoodStats`] Use `SetTooltipString` for potions

### DIFF
--- a/Tweaks/Tooltips/FoodStats.cs
+++ b/Tweaks/Tooltips/FoodStats.cs
@@ -163,7 +163,7 @@ namespace SimpleTweaksPlugin.Tweaks.Tooltips {
                     potionMaxPayload.Text = $"{max}";
                     potionActualValuePayload.Text = $"{actual}";
 
-                    stringArrayData->SetValue((int) TooltipTweaks.ItemTooltipField.Effects, seStr.Encode(), false);
+                    SetTooltipString(stringArrayData, TooltipTweaks.ItemTooltipField.Effects, seStr);
                 }
 
 


### PR DESCRIPTION
This pull request aims to fix a possible crash caused by the `FoodStats` tweak. The tweak was using `stringArrayData->SetValue(int, byte[], bool)` which ultimately resolved to `SetValueForced(int, byte*, bool)` via implicit conversion of `byte[]`. Per [a prior discussion](https://canary.discord.com/channels/581875019861328007/929533532185956352/1175485246565781605) this might cause an issue if things are GC'd, so it has been updated to use the newer/safer `SetTooltipString`.

It appears as though this specific call was just missed in commit 2826f17e and subsequently was never updated to use the `managed` variant in b5ec996b.

I've also verified that no other places in the code use the older `->SetValue` format via search, so this should be the last of these specific crashes. I'm not actually sure that this *will* fix the crash, but at the very least it's bringing some extra continuity to the code.