### PR TITLE
[`EquipJobCommand`] New Tweak

### DIFF
--- a/Tweaks/EquipJobCommand.cs
+++ b/Tweaks/EquipJobCommand.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using Dalamud.Utility;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using ImGuiNET;
+using Lumina.Excel.GeneratedSheets;
+using SimpleTweaksPlugin.Tweaks.AbstractTweaks;
+
+namespace SimpleTweaksPlugin.Tweaks;
+
+public unsafe class EquipJobCommand : CommandTweak
+{
+    public override string Name => "Equip Job Command";
+    public override string Description => "Adds a command to switch to a job's gearset.";
+    protected override string Command => "equipjob";
+    protected override string HelpMessage => "Switches to the highest item-level gearset for a job.";
+    protected override DrawConfigDelegate DrawConfigTree => (ref bool _) => ImGui.Text($"/{Command}");
+
+    protected override void OnCommand(string arguments)
+    {
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            Service.Chat.PrintError("/equipjob (job abbreviation)");
+            return;
+        }
+
+        var sheet = Service.Data.GetExcelSheet<ClassJob>();
+        var classJob =
+            from row in sheet
+            where row.Abbreviation.ToDalamudString().ToString().ToLower() == arguments.ToLower()
+            select row.RowId;
+        var id = classJob.FirstOrDefault((uint)0);
+        if (id == 0)
+            Service.Chat.PrintError($"Unable to find job {arguments}");
+        else
+            SwitchClassJob(id);
+    }
+
+    private void SwitchClassJob(uint classJobId)
+    {
+        var raptureGearsetModule = RaptureGearsetModule.Instance();
+        if (raptureGearsetModule == null)
+            return;
+
+        var bestGearset = Enumerable.Range(0, 100)
+            .Where(raptureGearsetModule->IsValidGearset)
+            .Select(gsid =>
+            {
+                var gearset = raptureGearsetModule->GetGearset(gsid);
+                return (Id: gearset->ID, ClassJob: gearset->ClassJob, ILvl: gearset->ItemLevel);
+            })
+            .Where(x => x.ClassJob == classJobId)
+            .OrderByDescending(x => x.ILvl)
+            .FirstOrDefault();
+        if (bestGearset.ClassJob != 0)
+        {
+            Service.Chat.Print($"Equipping gearset #{bestGearset.Id}");
+            raptureGearsetModule->EquipGearset(bestGearset.Id);
+        }
+        else
+        {
+            Service.Chat.PrintError("No suitable gearset found");
+        }
+    }
+}

--- a/Tweaks/EquipJobCommand.cs
+++ b/Tweaks/EquipJobCommand.cs
@@ -1,45 +1,146 @@
+using System;
 using System.Linq;
+using System.Numerics;
 using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using ImGuiNET;
 using Lumina.Excel.GeneratedSheets;
 using SimpleTweaksPlugin.Tweaks.AbstractTweaks;
+using SimpleTweaksPlugin.TweakSystem;
 
 namespace SimpleTweaksPlugin.Tweaks;
 
+[TweakAuthor("Lumina Sapphira")]
 public unsafe class EquipJobCommand : CommandTweak
 {
     public override string Name => "Equip Job Command";
-    public override string Description => "Adds a command to switch to a job's gearset.";
+    public override string Description => "Adds a command to switch to a class or job's gearset.";
     protected override string Command => "equipjob";
     protected override string HelpMessage => "Switches to the highest item-level gearset for a job.";
-    protected override DrawConfigDelegate DrawConfigTree => (ref bool _) => ImGui.Text($"/{Command}");
+
+    private class Config : TweakConfig
+    {
+        public bool AllowPriority;
+    }
+
+    private Config TweakConfig { get; set; } = null!;
+
+    protected override DrawConfigDelegate DrawConfigTree => (ref bool _) =>
+    { 
+        if (ImGui.Checkbox(LocString("PriorityName", "Allow priority list of jobs? (Only allows using abbreviations)", "Allow Priority Config Option"), ref TweakConfig.AllowPriority))
+        {
+            SaveConfig(TweakConfig);
+        }
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.SetNextWindowSize(new Vector2(280, -1));
+            ImGui.BeginTooltip();
+            ImGui.TextWrapped(LocString("PriorityHelp", "Useful when generalizing between classes / jobs (e.g. /equipjob pld gla)", "Allow Priority Tooltip"));
+            ImGui.EndTooltip();
+        }
+        ImGui.Separator();
+        ImGui.Text($"/{Command}");
+    };
+
+    protected override void Enable()
+    {
+        TweakConfig = LoadConfig<Config>() ?? new Config();
+        base.Enable();
+    }
+
+    protected override void Disable()
+    {
+        SaveConfig(TweakConfig);
+        base.Disable();
+    }
 
     protected override void OnCommand(string arguments)
     {
         if (string.IsNullOrWhiteSpace(arguments))
         {
-            Service.Chat.PrintError($"/{Command} (priority list of job abbreviations / names)");
+            if (TweakConfig.AllowPriority)
+                Service.Chat.PrintError($"/{Command} (priority list of job abbreviations...)");
+            else
+                Service.Chat.PrintError($"/{Command} (job abbreviation / name)");
             return;
+        }
+
+        if (TweakConfig.AllowPriority)
+        {
+            var options = arguments.Split(" ");
+            foreach (var option in options)
+            {
+                switch (TrySwitchClassJob(option, true)) 
+                {
+                    case SwitchClassJobResult.Success:
+                        return;
+                    case SwitchClassJobResult.FailedToFindGearset:
+                        continue;
+                    case SwitchClassJobResult.FailedToFindClassJob:
+                        Service.Chat.PrintError($"Bad job/class abbreviation: \"{option}\"");
+                        continue;
+                    case SwitchClassJobResult.InternalError:
+                        Service.Chat.PrintError("An error occurred.");
+                        return;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+        else
+        {
+            switch (TrySwitchClassJob(arguments, false))
+            {
+                case SwitchClassJobResult.Success:
+                    break;
+                case SwitchClassJobResult.FailedToFindGearset:
+                    Service.Chat.PrintError("No suitable gearset found");
+                    break;
+                case SwitchClassJobResult.FailedToFindClassJob:
+                    Service.Chat.PrintError($"Unable to find job {arguments}");
+                    break;
+                case SwitchClassJobResult.InternalError:
+                    Service.Chat.PrintError("An error occurred.");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+        
+    }
+
+    private enum SwitchClassJobResult
+    {
+        Success,
+        FailedToFindGearset,
+        FailedToFindClassJob,
+        InternalError
+    }
+
+    private static SwitchClassJobResult TrySwitchClassJob(string arg, bool abbreviationsOnly)
+    {
+        bool ComparisonDelegate(ClassJob row)
+        {
+            var abbr = row.Abbreviation.ToDalamudString().ToString().ToLower().Equals(arg.ToLower());
+            if (abbreviationsOnly || abbr) return abbr;
+            return row.Name.ToDalamudString().ToString().ToLower().Equals(arg.ToLower());
         }
 
         var sheet = Service.Data.GetExcelSheet<ClassJob>();
         var classJob =
             from row in sheet
-            where row.Abbreviation.ToDalamudString().ToString().ToLower() == arguments.ToLower() || row.Name.ToDalamudString().ToString().ToLower() == arguments.ToLower()
+            where ComparisonDelegate(row)
             select row.RowId;
         var id = classJob.FirstOrDefault((uint)0);
-        if (id == 0)
-            Service.Chat.PrintError($"Unable to find job {arguments}");
-        else
-            SwitchClassJob(id);
+        return id == 0 ?
+            SwitchClassJobResult.FailedToFindClassJob : SwitchClassJobID(id);
     }
 
-    private static void SwitchClassJob(uint classJobId)
+    private static SwitchClassJobResult SwitchClassJobID(uint classJobId)
     {
         var raptureGearsetModule = RaptureGearsetModule.Instance();
         if (raptureGearsetModule == null)
-            return;
+            return SwitchClassJobResult.InternalError;
 
         var bestGearset = Enumerable.Range(0, 100)
             .Where(raptureGearsetModule->IsValidGearset)
@@ -51,14 +152,9 @@ public unsafe class EquipJobCommand : CommandTweak
             .Where(x => x.ClassJob == classJobId)
             .OrderByDescending(x => x.ILvl)
             .FirstOrDefault();
-        if (bestGearset.ClassJob != 0)
-        {
-            Service.Chat.Print($"Equipping gearset #{bestGearset.Id + 1}");
-            raptureGearsetModule->EquipGearset(bestGearset.Id);
-        }
-        else
-        {
-            Service.Chat.PrintError("No suitable gearset found");
-        }
+        if (bestGearset.ClassJob == 0) return SwitchClassJobResult.FailedToFindGearset;
+        raptureGearsetModule->EquipGearset(bestGearset.Id);
+        Service.Chat.Print($"Equipping gearset #{bestGearset.Id + 1}");
+        return SwitchClassJobResult.Success;
     }
 }

--- a/Tweaks/EquipJobCommand.cs
+++ b/Tweaks/EquipJobCommand.cs
@@ -19,7 +19,7 @@ public unsafe class EquipJobCommand : CommandTweak
     {
         if (string.IsNullOrWhiteSpace(arguments))
         {
-            Service.Chat.PrintError("/equipjob (job abbreviation)");
+            Service.Chat.PrintError($"/{Command} (job abbreviation)");
             return;
         }
 

--- a/Tweaks/EquipJobCommand.cs
+++ b/Tweaks/EquipJobCommand.cs
@@ -53,7 +53,7 @@ public unsafe class EquipJobCommand : CommandTweak
             .FirstOrDefault();
         if (bestGearset.ClassJob != 0)
         {
-            Service.Chat.Print($"Equipping gearset #{bestGearset.Id}");
+            Service.Chat.Print($"Equipping gearset #{bestGearset.Id + 1}");
             raptureGearsetModule->EquipGearset(bestGearset.Id);
         }
         else

--- a/Tweaks/EquipJobCommand.cs
+++ b/Tweaks/EquipJobCommand.cs
@@ -19,14 +19,14 @@ public unsafe class EquipJobCommand : CommandTweak
     {
         if (string.IsNullOrWhiteSpace(arguments))
         {
-            Service.Chat.PrintError($"/{Command} (job abbreviation)");
+            Service.Chat.PrintError($"/{Command} (priority list of job abbreviations / names)");
             return;
         }
 
         var sheet = Service.Data.GetExcelSheet<ClassJob>();
         var classJob =
             from row in sheet
-            where row.Abbreviation.ToDalamudString().ToString().ToLower() == arguments.ToLower()
+            where row.Abbreviation.ToDalamudString().ToString().ToLower() == arguments.ToLower() || row.Name.ToDalamudString().ToString().ToLower() == arguments.ToLower()
             select row.RowId;
         var id = classJob.FirstOrDefault((uint)0);
         if (id == 0)
@@ -35,7 +35,7 @@ public unsafe class EquipJobCommand : CommandTweak
             SwitchClassJob(id);
     }
 
-    private void SwitchClassJob(uint classJobId)
+    private static void SwitchClassJob(uint classJobId)
     {
         var raptureGearsetModule = RaptureGearsetModule.Instance();
         if (raptureGearsetModule == null)

--- a/strings.json
+++ b/strings.json
@@ -391,6 +391,22 @@
     "message": "Emote Log Subcommand",
     "description": "[EmoteLogSubcommand] Tweak Name"
   },
+  "EquipJobCommand / Description": {
+    "message": "Adds a command to switch to a class or job's gearset.",
+    "description": "[EquipJobCommand] Tweak Description"
+  },
+  "EquipJobCommand / Name": {
+    "message": "Equip Job Command",
+    "description": "[EquipJobCommand] Tweak Name"
+  },
+  "EquipJobCommand / PriorityHelp": {
+    "message": "Useful when generalizing between classes / jobs (e.g. /equipjob pld gla)",
+    "description": "[EquipJobCommand] Allow Priority Tooltip"
+  },
+  "EquipJobCommand / PriorityName": {
+    "message": "Allow priority list of jobs? (Only allows using abbreviations)",
+    "description": "[EquipJobCommand] Allow Priority Config Option"
+  },
   "EstateListCommand / Description": {
     "message": "Adds a command to open the estate list of one of your friends. (/estatelist)",
     "description": "[EstateListCommand] Tweak Description"


### PR DESCRIPTION
Adds a command to switch to a gearset given a job's abbreviation.

Inspired by the desire to have gearset index -independent macros.

Implementation details:

- The job's abbreviation is not case-sensitive.
- The highest item level gearset is selected
- Job abbreviations are pulled from excel

Will gladly accept suggestions, fixes, etc. It's been a _long_ time since I've used C#.