### PR TITLE
[`StickyShoutChat`] Add New Tweak

### DIFF
--- a/Tweaks/Chat/StickyShoutChat.cs
+++ b/Tweaks/Chat/StickyShoutChat.cs
@@ -1,0 +1,19 @@
+﻿using Dalamud.Utility.Signatures;
+using FFXIVClientStructs.FFXIV.Client.UI.Shell;
+using SimpleTweaksPlugin.TweakSystem;
+using SimpleTweaksPlugin.Utility;
+
+namespace SimpleTweaksPlugin.Tweaks.Chat; 
+
+[TweakReleaseVersion(UnreleasedVersion)]
+public unsafe class StickyShoutChat : ChatTweaks.SubTweak {
+    public override string Name => "Sticky Shout Chat";
+    public override string Description => "Prevents the game from automatically switching out of shout chat.";
+    
+    private delegate void FocusPreviousChatChannelDelegate(RaptureShellModule* self);
+
+    [TweakHook, Signature("E8 ?? ?? ?? ?? 33 C0 49 8B CE", DetourName = nameof(SkipFocusChannel))]
+    private readonly HookWrapper<FocusPreviousChatChannelDelegate> focusPreviousChannelHook;
+
+    private void SkipFocusChannel(RaptureShellModule* self) { }
+}


### PR DESCRIPTION
This pull request aims to add a new Tweak to make shout chat (and similar resetting channels) sticky.

The game appears to track temporary chat channels in `RaptureShellModule+10B4`, set in `ffxiv_dx11.exe+787E10`. This is then reset in `ffxiv_dx11.exe+787F00` if the return chat channel is not `-2`.

I opted to simply wipe out `787F00`, but I suppose the "return" channel can be set to -2 instead. This feels safer than intercepting and changing the behavior of `787E10` as a number of other things seem to get set in that method (although these are all reverted in `787F00`).

This design *might* have some stray side effects, but seems to perform reasonably in testing. Disabling the tweak while in `/shout` chat dumps you back to wherever you're supposed to be. As this design further only deals with `RaptureShellModule`, the UI *should* consistently retain an accurate view of whatever the channel is going to be - leading to no user surprises.

I have noticed that say -> shout -> alliance -> shout -> tweak disable will take you back to the say channel - this is caused by `787E10` only updating the temporary channel if it's -2. I don't think this is an issue, strictly speaking, but a sanity check that this won't cause further odd behavior would be appreciated. 