### PR TITLE
HideCrossbarhints Was Not Working in HideTooltipsInCombat.cs

### DIFF
--- a/Tweaks/Tooltips/HideTooltipsInCombat.cs
+++ b/Tweaks/Tooltips/HideTooltipsInCombat.cs
@@ -158,7 +158,7 @@ public unsafe class HideTooltipsInCombat : TooltipTweaks.SubTweak {
             SetVisible("ActionDetailDisp", !Config.HideActionOoc);
             SetVisible("ItemDetailDisp", !Config.HideItemOoc);
             SetVisible("ToolTipDisp", !Config.HidePopUpOoc);
-            SetVisible("HotbarCrossHelpDisp", !Config.HidePopUpOoc, true);
+            SetVisible("HotbarCrossHelpDisp", !Config.HideCrossbarHintsOoc, true);
         }
     }
 }


### PR DESCRIPTION
Hiding crossbar hints out of combat wasn't working because it was duplicated and set to HidePopUpOoc instead.

Changing the duplicate Config.HidePopUpOoc to Config.HideCrossbarHintsOoc fixes this