### PR TITLE
Use origins when calculating scaled node position

### DIFF
--- a/Debugging/UIDebug.cs
+++ b/Debugging/UIDebug.cs
@@ -1413,10 +1413,12 @@ public unsafe class UIDebug : DebugHelper {
         
     private static Vector2 GetNodePosition(AtkResNode* node) {
         var pos = new Vector2(node->X, node->Y);
+        pos -= new Vector2(node->OriginX * (node->ScaleX - 1), node->OriginY * (node->ScaleY - 1));
         var par = node->ParentNode;
         while (par != null) {
             pos *= new Vector2(par->ScaleX, par->ScaleY);
             pos += new Vector2(par->X, par->Y);
+            pos -= new Vector2(par->OriginX * (par->ScaleX - 1), par->OriginY * (par->ScaleY - 1));
             par = par->ParentNode;
         }
         return pos;


### PR DESCRIPTION
Changes `GetNodePosition` to consider the node's (and parent nodes') `OriginX` and `OriginY` when calculating node position. This makes `DrawOutline` draw the correct position for nodes and the children of nodes with a non-zero scale origin.

Tested with various situations including origin-scaled children of origin-scaled parent and things seemed to work fine with this logic.