### PR TITLE
Update DisableMountVolumeChange

### DIFF
--- a/SimpleTweaksPlugin.csproj
+++ b/SimpleTweaksPlugin.csproj
@@ -33,7 +33,6 @@
         <Compile Remove="Tweaks\CutsceneCommands.cs"/>
         <Compile Remove="Tweaks\DataCentreOnTitleScreen.cs"/>
         <Compile Remove="Tweaks\DisableClickTargeting.cs"/>
-        <Compile Remove="Tweaks\DisableMountVolumeChange.cs"/>
         <Compile Remove="Tweaks\DisableMouseCameraControl.cs"/>
         <Compile Remove="Tweaks\EquipFromHotbar.cs"/>
         <Compile Remove="Tweaks\FixedShadowDistance.cs"/>

--- a/Tweaks/DisableMountVolumeChange.cs
+++ b/Tweaks/DisableMountVolumeChange.cs
@@ -3,32 +3,53 @@ using SimpleTweaksPlugin.Utility;
 
 namespace SimpleTweaksPlugin.Tweaks; 
 
+[TweakName("Disable Mount Music Volume Change")]
+[TweakAuthor("perchbird")]
+[TweakDescription("Prevents mount music from going quiet when not moving.")]
+[TweakCategory(TweakCategory.QoL)]
 public unsafe class DisableMountVolumeChange : Tweak {
-    public override string Name => "Disable Mount Music Volume Change";
-    public override string Description => "Prevents mount music from going quiet when not moving.";
-    protected override string Author => "perchbird";
     
-    private delegate int GetSpecialMode(void* unused, byte specialModeType);
+    private delegate void GetSpecialMode(byte* bgmPlayer);
+    private delegate void UpdateFromSpecialMode(byte* a1, int isMountLoud);
     private HookWrapper<GetSpecialMode> getSpecialModeHook;
+    private HookWrapper<UpdateFromSpecialMode> updateFromSpecialModeHook;
+
+    private int specialModeType;
 
     protected override void Enable() {
-        getSpecialModeHook ??= Common.Hook<GetSpecialMode>("48 89 5C 24 ?? 57 48 83 EC 20 8B 41 10 33 DB", GetSpecialModeDetour);
+        getSpecialModeHook ??= Common.Hook<GetSpecialMode>("40 57 48 83 EC 20 48 83 79 ?? ?? 48 8B F9 0F 84 ?? ?? ?? ?? 0F B6 51 4D", GetSpecialModeDetour);
+        updateFromSpecialModeHook ??= Common.Hook<UpdateFromSpecialMode>("8B 81 ?? ?? ?? ?? 85 C0 74 05 83 F8 02", UpdateFromSpecialModeDetour);
         getSpecialModeHook?.Enable();
+        updateFromSpecialModeHook?.Enable();
         base.Enable();
     }
 
-    private int GetSpecialModeDetour(void* unused, byte specialModeType)
+    private void GetSpecialModeDetour(byte* bgmPlayer)
     {
-        return specialModeType == 2 ? 4 : getSpecialModeHook.Original(unused, specialModeType);
+        specialModeType = *(bgmPlayer + 0x4D);
+        getSpecialModeHook.Original(bgmPlayer);
+    }
+    
+    private void UpdateFromSpecialModeDetour(byte* a1, int isMountLoud)
+    {
+        if (specialModeType != 2)
+        {
+            updateFromSpecialModeHook.Original(a1, isMountLoud);
+            return;
+        }
+
+        updateFromSpecialModeHook.Original(a1, 1);
     }
 
     protected override void Disable() {
         getSpecialModeHook?.Disable();
+        updateFromSpecialModeHook?.Disable();
         base.Disable();
     }
 
     public override void Dispose() {
         getSpecialModeHook?.Dispose();
+        updateFromSpecialModeHook?.Dispose();
         base.Dispose();
     }
 }


### PR DESCRIPTION
Some of the functions that handled BGM state got brought into the GetSpecialMode function. Since the function now operates on the field directly in the BGMPlayer structure, setting it before or after the function will do nothing. Therefore, the hook stores the special mode type to utilize for another hook, UpdateFromSpecialMode. This function receives a 1 for the 2nd arg if the special mode from GetSpecialMode is 4.

In the end, we can entirely ignore the special mode and call UpdateFromSpecialMode with a 1 if we're on a mount (special mode type 2), and it works fine.