### PR TITLE
Actually show AtkUldPart

### DIFF
--- a/Debugging/UIDebug.cs
+++ b/Debugging/UIDebug.cs
@@ -902,8 +902,10 @@ public unsafe class UIDebug : DebugHelper {
                                     ImGui.Text($"[U: {u}  V: {v}  W: {width}  H: {height}]");
                                 }
 
-                                ImGui.Image(new IntPtr(kernelTexture->D3D11ShaderResourceView), new Vector2(width, height),
-                                    new Vector2(u, v) / textureSize, new Vector2(u + width, v + height) / textureSize);
+                                if (tPart.UldAsset is not null && tPart.UldAsset->AtkTexture.Resource is not null && tPart.UldAsset->AtkTexture.Resource->KernelTextureObject is not null) {
+                                    ImGui.Image(new IntPtr(tPart.UldAsset->AtkTexture.Resource->KernelTextureObject->D3D11ShaderResourceView), new Vector2(width, height),
+                                        new Vector2(u, v) / textureSize, new Vector2(u + width, v + height) / textureSize);   
+                                }
                             }
 
                             ImGui.EndTable();


### PR DESCRIPTION
Currently the debug view only shows the uv coordinates for the texture loaded in the root part, it doesn't check each individual part.

The vanilla game doesn't seem to use different textures within a parts list, but KamiToolKit does, I allocate several textures in parts for ease of switching.

![image](https://github.com/user-attachments/assets/23135f46-5648-4490-a2c0-430ec1a2df6e)
