### PR TITLE
Update Fade Unavailable Actions

### DIFF
--- a/SimpleTweaksPlugin.csproj
+++ b/SimpleTweaksPlugin.csproj
@@ -57,7 +57,6 @@
         <Compile Remove="Tweaks\UiAdjustment\ColoredDutyRoulette.cs"/>
         <Compile Remove="Tweaks\UiAdjustment\CustomDefaultQuantity.cs"/>
         <Compile Remove="Tweaks\UiAdjustment\CustomFreeCompanyTags.cs"/>
-        <Compile Remove="Tweaks\UiAdjustment\FadeUnavailableActions.cs"/>
         <Compile Remove="Tweaks\UiAdjustment\FastSearch.cs"/>
         <Compile Remove="Tweaks\UiAdjustment\HideGuildhestObjectivePopup.cs"/>
         <Compile Remove="Tweaks\UiAdjustment\HideQualityWhenNoHQ.cs"/>


### PR DESCRIPTION
Square added at least one new action type that threw off the enum, and added one more int value to the NumberArrayStruct, shifting IsTargetable down one entry.

The sig broke as well, but only very slightly.