### PR TITLE
Update Color Duty Roulette Names

### DIFF
--- a/Tweaks/UiAdjustment/ColoredDutyRoulette.cs
+++ b/Tweaks/UiAdjustment/ColoredDutyRoulette.cs
@@ -14,6 +14,7 @@ using Lumina.Excel.GeneratedSheets;
 using SimpleTweaksPlugin.Events;
 using SimpleTweaksPlugin.TweakSystem;
 using SimpleTweaksPlugin.Utility;
+using InstanceContent = FFXIVClientStructs.FFXIV.Client.Game.UI.InstanceContent;
 
 namespace SimpleTweaksPlugin.Tweaks.UiAdjustment;
 
@@ -72,7 +73,7 @@ public unsafe partial class ColoredDutyRoulette : UiAdjustments.SubTweak {
         }
     }
     
-    public override void Setup() {
+    protected override void Setup() {
         foreach (var entry in Service.Data.GetExcelSheet<ContentRoulette>()!.Where(roulette => roulette.Name != string.Empty)) {
             var filteredName = Alphanumeric().Replace(entry.Category.ToString().ToLower(), string.Empty);
             rouletteIdDictionary.TryAdd(filteredName, entry.RowId);
@@ -108,7 +109,7 @@ public unsafe partial class ColoredDutyRoulette : UiAdjustments.SubTweak {
                 continue;
             }
 
-            switch (RouletteController.Instance()->IsRouletteComplete((byte) rouletteId)) {
+            switch (InstanceContent.Instance()->IsRouletteComplete((byte) rouletteId)) {
                 case true when TweakConfig.ColorCompleteRoulette && TweakConfig.EnabledRoulettes.Contains(rouletteId):
                     SetNodeColor(textNode, TweakConfig.CompleteColor);
                     break;


### PR DESCRIPTION
No logic changes.

DailyDuty now also has this functionality but it depends on including roulettes in the todo / notification / tracking. Since I'd like this to apply to all roulettes, but only have certain roulettes in my DailyDuty todo list, this tweak is still useful.