### PR TITLE
[`LevelingDungeonCommand`] New Tweak: Command to open highest level leveling dungeon available to the player

### DIFF
--- a/Tweaks/LevelingDungeonCommand.cs
+++ b/Tweaks/LevelingDungeonCommand.cs
@@ -11,7 +11,7 @@ namespace SimpleTweaksPlugin.Tweaks;
 
 [TweakName("Leveling Dungeon Command")]
 [TweakDescription("Adds a command to open the highest level leveling dungeon available for your level.")]
-[TweakReleaseVersion("0.0.0.0")]
+[TweakReleaseVersion(UnreleasedVersion)]
 [TweakAuthor("LuminaSapphira")]
 public class LevelingDungeonCommand : CommandTweak
 {

--- a/Tweaks/LevelingDungeonCommand.cs
+++ b/Tweaks/LevelingDungeonCommand.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using Lumina.Excel.GeneratedSheets;
+using SimpleTweaksPlugin.Tweaks.AbstractTweaks;
+using SimpleTweaksPlugin.TweakSystem;
+using SimpleTweaksPlugin.Utility;
+
+namespace SimpleTweaksPlugin.Tweaks;
+
+[TweakName("Leveling Dungeon Command")]
+[TweakDescription("Adds a command to open the highest level leveling dungeon available for your level.")]
+[TweakReleaseVersion("0.0.0.0")]
+[TweakAuthor("LuminaSapphira")]
+public class LevelingDungeonCommand : CommandTweak
+{
+    protected override string Command => "/levelingdungeon";
+
+    protected override string HelpMessage => "Open the highest level leveling dungeon.";
+    
+    protected override unsafe void OnCommand(string args)
+    {
+        if (Service.Condition.Cutscene()) {
+            Service.Chat.PrintError("You cannot open the Duty Finder during a cutscene.");
+            return;
+        }
+
+        if (Service.Condition.Duty()) {
+            Service.Chat.PrintError("You cannot open the Duty Finder while in a duty.");
+            return;
+        }
+
+        var sheet = Service.Data.GetExcelSheet<ContentFinderCondition>();
+        var row = sheet?
+            .Where(row => row.ContentType.Row == (uint)InstanceContentType.Dungeon)
+            .Where(row => UIState.IsInstanceContentUnlocked(row.Content))
+            .Where(row => row.ClassJobLevelRequired <= UIState.Instance()->PlayerState.CurrentLevel)
+            .Where(row => row.ClassJobLevelRequired % 10 != 0) // Only leveling dungeons
+            .MaxBy(row => row.ClassJobLevelRequired);
+        var id = row?.RowId;
+
+        if (id.HasValue)
+            AgentContentsFinder.Instance()->OpenRegularDuty(id.Value);
+        else
+            Service.Chat.PrintError("Failed to find a valid leveling dungeon.");
+    }
+}


### PR DESCRIPTION
Adds a new command to open the highest level leveling dungeon available to the player in the Duty Finder. A quick QoL to avoid having to scroll through the duty list or remember what's best for your level. Intended to be macro'd or QoLBar'd, but direct input is also feasible.

No subcommands / arguments / settings. Uses excel sheet data to list the available instance content in the game, filters by those that are dungeons, where `RequiredClassJobLevel % 10 == 0`, those that are unlocked by the player, and those that have a required level less than the player's current level on their current job, then selects the max level dungeon of that list.

I tinkered with having an option to auto-check-checkbox-for-queueing but couldn't figure it out in <10 minutes so I went to bed. 