### PR TITLE
[`TryOnCorrectItem`] Fix incorrect icon

### DIFF
--- a/Tweaks/TryOnCorrectItem.cs
+++ b/Tweaks/TryOnCorrectItem.cs
@@ -152,6 +152,7 @@ public class TryOnCorrectItem : Tweak {
         var c = GetActiveWindowSettings();
         var i = c.NoModifier;
         if (Service.KeyState[VirtualKey.SHIFT]) i = c.HoldingShift;
-        return tryOnHook.Original(openerAddonId, itemId, stain0Id, stain1Id, i == TryOnItem.Original ? itemId : glamourItemId, applyCompanyCrest);
+        if (i == TryOnItem.Original) return tryOnHook.Original(openerAddonId, itemId, stain0Id, stain1Id, itemId, applyCompanyCrest);
+        return tryOnHook.Original(openerAddonId, glamourItemId, stain0Id, stain1Id, glamourItemId, applyCompanyCrest);
     }
 }


### PR DESCRIPTION
Fixes the icon to match the displayed appearance when showing the "original" item.