### PR TITLE
Update and simplify ChatHelper

### DIFF
--- a/Utility/ChatHelper.cs
+++ b/Utility/ChatHelper.cs
@@ -1,159 +1,58 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
-using System.Text;
-using FFXIVClientStructs.FFXIV.Client.System.Memory;
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using Framework = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework;
+using FFXIVClientStructs.FFXIV.Client.UI;
 
 // Original:
 //      https://git.anna.lgbt/ascclemens/XivCommon/src/branch/main/XivCommon/Functions/Chat.cs
 
-namespace SimpleTweaksPlugin.Utility; 
+namespace SimpleTweaksPlugin.Utility;
 
 /// <summary>
 /// A class containing chat functionality
 /// </summary>
 public static class ChatHelper {
-    private static class Signatures {
-        internal const string SendChat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 45 84 C9";
-        internal const string SanitiseString = "E8 ?? ?? ?? ?? 48 8D 4C 24 ?? 0F B6 F0 E8 ?? ?? ?? ?? 48 8D 4D C0";
-    }
-
-    private delegate void ProcessChatBoxDelegate(IntPtr uiModule, IntPtr message, IntPtr unused, byte a4);
-
-    private static ProcessChatBoxDelegate? ProcessChatBox { get; }
-
-    private static readonly unsafe delegate* unmanaged<Utf8String*, int, IntPtr, void> _sanitiseString = null!;
-
-    static ChatHelper() {
-        if (Service.SigScanner.TryScanText(Signatures.SendChat, out var processChatBoxPtr)) {
-            ProcessChatBox = Marshal.GetDelegateForFunctionPointer<ProcessChatBoxDelegate>(processChatBoxPtr);
-        }
-
-        unsafe {
-            if (Service.SigScanner.TryScanText(Signatures.SanitiseString, out var sanitisePtr)) {
-                _sanitiseString = (delegate* unmanaged<Utf8String*, int, IntPtr, void>) sanitisePtr;
-            }
-        }
-    }
-
     /// <summary>
     /// <para>
     /// Send a given message to the chat box. <b>This can send chat to the server.</b>
     /// </para>
     /// <para>
-    /// <b>This method is unsafe.</b> This method does no checking on your input and
-    /// may send content to the server that the normal client could not. You must
-    /// verify what you're sending and handle content and length to properly use
-    /// this.
-    /// </para>
-    /// </summary>
-    /// <param name="message">Message to send</param>
-    /// <exception cref="InvalidOperationException">If the signature for this function could not be found</exception>
-    public static unsafe void SendMessageUnsafe(byte[] message) {
-        if (ProcessChatBox == null) {
-            throw new InvalidOperationException("Could not find signature for chat sending");
-        }
-
-        var uiModule = (IntPtr) Framework.Instance()->GetUIModule();
-
-        using var payload = new ChatPayload(message);
-        var mem1 = Marshal.AllocHGlobal(400);
-        Marshal.StructureToPtr(payload, mem1, false);
-
-        ProcessChatBox(uiModule, mem1, IntPtr.Zero, 0);
-
-        Marshal.FreeHGlobal(mem1);
-    }
-
-    /// <summary>
-    /// <para>
-    /// Send a given message to the chat box. <b>This can send chat to the server.</b>
-    /// </para>
-    /// <para>
-    /// This method is slightly less unsafe than <see cref="SendMessageUnsafe"/>. It
-    /// will throw exceptions for certain inputs that the client can't normally send,
-    /// but it is still possible to make mistakes. Use with caution.
+    /// This method will throw exceptions for certain inputs that the client can't
+    /// normally send, but it is still possible to make mistakes. Use with caution.
     /// </para>
     /// </summary>
     /// <param name="message">message to send</param>
     /// <exception cref="ArgumentException">If <paramref name="message"/> is empty, longer than 500 bytes in UTF-8, or contains invalid characters.</exception>
-    /// <exception cref="InvalidOperationException">If the signature for this function could not be found</exception>
-    public static void SendMessage(string message) {
-        var bytes = Encoding.UTF8.GetBytes(message);
-        if (bytes.Length == 0) {
-            throw new ArgumentException("message is empty", nameof(message));
-        }
+    /// <exception cref="InvalidOperationException">If the signature for this function could not be found -or- The UiModule is currently unavailable</exception>
+    public static unsafe void SendMessage(string message) {
+        var utf8 = Utf8String.FromString(message);
 
-        if (bytes.Length > 500) {
-            throw new ArgumentException("message is longer than 500 bytes", nameof(message));
-        }
+        try {
+            if (utf8->Length == 0) {
+                throw new ArgumentException("message is empty", nameof(message));
+            }
 
-        if (message.Length != SanitiseText(message).Length) {
-            throw new ArgumentException("message contained invalid characters", nameof(message));
-        }
+            if (utf8->Length > 500) {
+                throw new ArgumentException("message is longer than 500 bytes", nameof(message));
+            }
 
-        SendMessageUnsafe(bytes);
-    }
+            var oldLength = utf8->Length;
 
-    /// <summary>
-    /// <para>
-    /// Sanitises a string by removing any invalid input.
-    /// </para>
-    /// <para>
-    /// The result of this method is safe to use with
-    /// <see cref="SendMessage"/>, provided that it is not empty or too
-    /// long.
-    /// </para>
-    /// </summary>
-    /// <param name="text">text to sanitise</param>
-    /// <returns>sanitised text</returns>
-    /// <exception cref="InvalidOperationException">If the signature for this function could not be found</exception>
-    public static unsafe string SanitiseText(string text) {
-        if (_sanitiseString == null) {
-            throw new InvalidOperationException("Could not find signature for chat sanitisation");
-        }
+            utf8->SanitizeString(0x27F, null);
 
-        var uText = Utf8String.FromString(text);
+            if (utf8->Length != oldLength) {
+                throw new ArgumentException($"message contained invalid characters", nameof(message));
+            }
 
-        _sanitiseString(uText, 0x27F, IntPtr.Zero);
-        var sanitised = uText->ToString();
+            var uiModule = UIModule.Instance();
+            if (uiModule == null) {
+                throw new InvalidOperationException("The UiModule is currently unavailable");
+            }
 
-        uText->Dtor();
-        IMemorySpace.Free(uText);
-
-        return sanitised;
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    [SuppressMessage("ReSharper", "PrivateFieldCanBeConvertedToLocalVariable")]
-    private readonly struct ChatPayload : IDisposable {
-        [FieldOffset(0)]
-        private readonly IntPtr textPtr;
-
-        [FieldOffset(16)]
-        private readonly ulong textLen;
-
-        [FieldOffset(8)]
-        private readonly ulong unk1;
-
-        [FieldOffset(24)]
-        private readonly ulong unk2;
-
-        internal ChatPayload(byte[] stringBytes) {
-            this.textPtr = Marshal.AllocHGlobal(stringBytes.Length + 30);
-            Marshal.Copy(stringBytes, 0, this.textPtr, stringBytes.Length);
-            Marshal.WriteByte(this.textPtr + stringBytes.Length, 0);
-
-            this.textLen = (ulong) (stringBytes.Length + 1);
-
-            this.unk1 = 64;
-            this.unk2 = 0;
-        }
-
-        public void Dispose() {
-            Marshal.FreeHGlobal(this.textPtr);
+            uiModule->ProcessChatBoxEntry(utf8);
+        } finally {
+            if (utf8 != null) {
+                utf8->Dtor(true);
+            }
         }
     }
 }


### PR DESCRIPTION
Use functions and types defined in ClientStructs instead of maintaining a version here

Additionally the helper functions were never used independently, so inline them and save a few conversions

At the time of writing this needs a for wait for a ClientStructs fix to make its way into Dalamud for it to compile and work correctly.

This fixes the tweaks that rely on chat commands to function.