### PR TITLE
[`OpenGlamourDresserToCurrentJob`] Fix vanishing window bug

### DIFF
--- a/Tweaks/UiAdjustment/OpenGlamourDresserToCurrentJob.cs
+++ b/Tweaks/UiAdjustment/OpenGlamourDresserToCurrentJob.cs
@@ -13,7 +13,7 @@ public unsafe class OpenGlamourDresserToCurrentJob : UiAdjustments.SubTweak {
     [AddonPreSetup("MiragePrismPrismBox")]
     private void OnMiragePrismBoxOpen(AtkUnitBase* atkUnitBase) {
         if (Service.ClientState is { LocalPlayer.ClassJob.RowId: var playerJob }) {
-            Marshal.WriteByte((nint)atkUnitBase, 416, (byte)playerJob);
+            Marshal.WriteByte((nint)atkUnitBase, 0x1A8, (byte)playerJob);
         }
     }
 }


### PR DESCRIPTION
The tweak was writing to the wrong byte (due to the way all addon offsets shifted in 7.1), causing the Glamour Dresser window to vanish.

This is a quick-fix that corrects the offset for now, but it would probably be best to get the field added to ClientStructs so it can be maintained there.