### PR TITLE
[`CaseInsensitiveCommands`] Casexile, but a Tweak!

### DIFF
--- a/Tweaks/Chat/CaseInsensitiveCommands.cs
+++ b/Tweaks/Chat/CaseInsensitiveCommands.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dalamud.Game.Command;
+using FFXIVClientStructs.FFXIV.Client.System.String;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Component.Shell;
+using Lumina.Excel.Sheets;
+using Lumina.Extensions;
+using Lumina.Text.ReadOnly;
+using SimpleTweaksPlugin.TweakSystem;
+using SimpleTweaksPlugin.Utility;
+
+namespace SimpleTweaksPlugin.Tweaks.Chat;
+
+[TweakName("Case Insensitive Text Commands")]
+[TweakAuthor("KazWolfe")]
+[TweakDescription("Allows text commands to be entered without caring about case.")]
+[TweakAutoConfig]
+public unsafe class CaseInsensitiveCommands : ChatTweaks.SubTweak
+{
+    public class Configs : TweakConfig
+    {
+        [TweakConfigOption("Resolve Dalamud-provided commands)")]
+        public bool ResolveDalamudCommands = true;
+    }
+
+    [TweakHook(typeof(ShellCommands), nameof(ShellCommands.TryInvokeDebugCommand), nameof(TryInvokeDebugCommandDetour))]
+    private HookWrapper<ShellCommands.Delegates.TryInvokeDebugCommand> _tryInvokeCommandHook = null!;
+
+    [TweakConfig] private Configs TweakConfig { get; set; } = null!;
+
+    private int TryInvokeDebugCommandDetour(ShellCommands* self, Utf8String* message, UIModule* uiModule)
+    {
+        var retval = _tryInvokeCommandHook.Original(self, message, uiModule);
+        if (retval != -1) return retval;
+
+        var parsed = message->ToString().Split(" ", 2);
+
+        if (FindInsensitiveGameCommand(parsed[0], out var matchedGameCommand))
+        {
+            // note: need to run this on next tick since we've already passed the point of command execution, but we're
+            // still in the "on receive chat input" phase.
+            Service.Framework.RunOnTick(() =>
+            {
+                ChatHelper.SendMessage(matchedGameCommand + (parsed.Length > 1 ? " " + parsed[1] : ""));
+            });
+            return 0;
+        }
+
+        if (TweakConfig.ResolveDalamudCommands && FindInsensitiveDalamudCommand(parsed[0], out var dalamudMatch))
+        {
+            Service.Commands.DispatchCommand(dalamudMatch.Key, parsed.Length > 1 ? parsed[1] : "", dalamudMatch.Value);
+            return 0;
+        }
+
+        return retval;
+    }
+
+    private static bool FindInsensitiveDalamudCommand(string query, out KeyValuePair<string, IReadOnlyCommandInfo> result)
+    {
+        var match = Service.Commands.Commands
+            .Where(tc => tc.Key.Equals(query, StringComparison.InvariantCultureIgnoreCase))
+            .FirstOrNull();
+
+        if (match != null)
+        {
+            result = match.Value;
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    private static bool FindInsensitiveGameCommand(string query, out string? result)
+    {
+        result = Service.Data.GetExcelSheet<TextCommand>()
+            .Select(textCommand => (List<ReadOnlySeString>)
+                [textCommand.Command, textCommand.ShortCommand, textCommand.Alias, textCommand.ShortAlias])
+            .SelectMany(potentials => potentials
+                .Select(potential => potential.ExtractText())
+                .Where(extracted => extracted.Equals(query, StringComparison.InvariantCultureIgnoreCase)))
+            .FirstOrDefault();
+
+        return result != null;
+    }
+}

--- a/Tweaks/CommandAlias.cs
+++ b/Tweaks/CommandAlias.cs
@@ -165,6 +165,11 @@ public class CommandAlias : Tweak {
                         if (!a.IsValid()) return false;
                         return splitString[0] == $"/{a.Input}";
                     });
+
+                    if (alias == null && Plugin.GetTweak<Chat.CaseInsensitiveCommands>().Enabled) {
+                        alias = TweakConfig.AliasList.FirstOrDefault(a => a.Enabled && a.IsValid() && splitString[0].Equals($"/{a.Input}", StringComparison.InvariantCultureIgnoreCase));
+                    }
+
                     if (alias != null) {
                         var commandExtra = inputString[(alias.Input.Length + 1)..];
                         if (commandExtra.StartsWith(' ')) commandExtra = commandExtra[1..];


### PR DESCRIPTION
Someone should probably verify this can be "adopted"... Anyways.

- Uses the same failed command handler logic as Dalamud does. This should always run post-Dalamud.
- Instead of just forcing the first word to lowercase, intelligently look up the command from Lumina.
  - This only makes a difference for GM commands, but hey. It's technically more correct!
  - It may make sense (possibly?) to cache these resolutions to not run a LINQ query every time. However, this isn't running per-frame so I'm not sure if it's a big deal.
- Add optional resolution for Dalamud commands as well, so people can use `/XLPlugins` and all.
  - This will also intelligently search through Dalamud's command registry, meaning plugins that register uppercase commands will be used if found first. (e.g. a plugin registering `/CoolCommand` will now be accessible via `/coolcommand`).

Command resolution order is: as-is command, case-insensitive game command, case-insensitive plugin command, default error response. Meaning:

- The first match for any case-insensitive search is found, so if two plugins register `/someCommand` and `/SomeCommand`, the earlier one registered will take priority when using `/somecommand`.
- If a plugin registers `/MountGuide`, `/MOUNTGUIDE` will always resolve to the game's variant.
  - If the user calls `/MountGuide`, it'll still be handled by the plugin since it's correct case.

I do not know how this plugin will interact with other plugins that perform their own command hooking; I suspect load order would kick in. So if, e.g., a plugin uses the same hook to listen for `/sam` for class-switch purposes, I'm not sure this one will necessarily resolve to that if the user types in `/SAM`.