### PR TITLE
`[Print Search Comment]` Remove unnecessary conversion to Dalamud SeString

### DIFF
--- a/Tweaks/Chat/PrintSearchComment.cs
+++ b/Tweaks/Chat/PrintSearchComment.cs
@@ -35,10 +35,9 @@ public class PrintSearchComment : ChatTweaks.SubTweak {
                     .Append(">")
                     .PopColorType()
                     .Append("\r")
-                    .Append(searchInfo)
-                    .ToArray();
+                    .Append(searchInfo);
 
-                Service.Chat.Print(SeString.Parse(builder));
+                Service.Chat.Print(builder.GetViewAsSpan());
             }
         } catch (Exception ex) {
             SimpleLog.Error(ex, $"Error in {GetType().Name} hook");


### PR DESCRIPTION
API 11 added new methods for print chat that allow the use of Lumina SeStrings directly, which removes the need for a conversion back to Dalamud SeString in this tweak