### PR TITLE
Blacklist crashing SubmarineDestinationLetters tweak

### DIFF
--- a/tweakBlacklist.txt
+++ b/tweakBlacklist.txt
@@ -4,3 +4,4 @@ UiAdjustments@ControlHintMirroring
 UiAdjustments@StopCraftingButton::2
 UiAdjustments@FadeUnavailableActions
 UiAdjustments@LockWindowPosition
+UiAdjustments@SubmarineDestinationLetters


### PR DESCRIPTION
Cf. #930, the crash is pretty random, but should probably blacklist the tweak until you or someone else can have a look at it.