### PR TITLE
[`AutoLockHotbar`] Add option to unlock when combat ends

### DIFF
--- a/Tweaks/AutoLockHotbar.cs
+++ b/Tweaks/AutoLockHotbar.cs
@@ -13,6 +13,9 @@ public unsafe class AutoLockHotbar : Tweak {
         [TweakConfigOption("Lock at beginning of combat.")]
         public bool CombatStart = true;
 
+        [TweakConfigOption("Unlock when combat ends.")]
+        public bool CombatEnd = false;
+
         [TweakConfigOption("Lock when changing zone.")]
         public bool ZoneChange = true;
         
@@ -26,8 +29,11 @@ public unsafe class AutoLockHotbar : Tweak {
         Service.Condition.ConditionChange += OnConditionChange;
     }
 
-    private void OnConditionChange(ConditionFlag flag, bool value) {
-        if (Config.CombatStart && flag == ConditionFlag.InCombat && value) SetLock(true);
+    private void OnConditionChange(ConditionFlag flag, bool value)
+    {
+        if (flag != ConditionFlag.InCombat) return;
+        if (Config.CombatStart && value) SetLock(true);
+        if (Config.CombatEnd && !value) SetLock(false);
     }
 
     [TerritoryChanged]


### PR DESCRIPTION
I use 3x4 Hotbars which leads to the lock being off-screen, making this the only way to unlock my hotbars if I want to change something outside of combat.

If wanted I can change it to default to being off.