### PR TITLE
[HideTargetHighlight] New tweak

### DIFF
--- a/Tweaks/UiAdjustment/HideTargetHighlight.cs
+++ b/Tweaks/UiAdjustment/HideTargetHighlight.cs
@@ -1,0 +1,70 @@
+﻿using System.Diagnostics;
+using System.Linq;
+using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Game.ClientState.Objects.Enums;
+using SimpleTweaksPlugin.Events;
+using SimpleTweaksPlugin.TweakSystem;
+
+namespace SimpleTweaksPlugin.Tweaks.UiAdjustment;
+
+[TweakName("Hide Target Hightlight/Outline")]
+[TweakDescription("Allow hiding the potential target outline while not in combat or dungeons.")]
+[TweakAutoConfig]
+[TweakAuthor("origamitoaster")]
+[TweakReleaseVersion("1.10.9.2")]
+public unsafe class HideTargetHighlight : UiAdjustments.SubTweak {
+    private readonly ushort[] nonCombatTerritory = {
+        1055, // Island Sanctuary
+    };
+
+    private readonly Stopwatch outOfCombatTimer = new();
+    public Configs Config { get; private set; }
+
+    private bool InCombatDuty => Service.Condition[ConditionFlag.BoundByDuty] && !nonCombatTerritory.Contains(Service.ClientState.TerritoryType);
+
+    protected override void Disable() => Update(true);
+    protected override void Enable() => outOfCombatTimer.Restart();
+
+    [FrameworkUpdate(NthTick = 30)] private void FrameworkUpdate() => Update();
+
+    private void Update(bool reset = false) {
+        var targetCircleShown = Service.GameConfig.UiControl.GetBool("ObjectBorderingType");
+        bool requestToBeShown = false;
+        bool requestToHide = false;
+
+        if (reset || Config.ShowInDuty && InCombatDuty) {
+            requestToBeShown = true;
+        } else if (Config.ShowInCombat && Service.Condition[ConditionFlag.InCombat]) {
+            requestToBeShown = true;
+            outOfCombatTimer.Restart();
+        } else if (Config.ShowInCombat && outOfCombatTimer.ElapsedMilliseconds < Config.CombatBuffer * 1000) {
+            requestToBeShown = true;
+        } else if (Config.ShowWhileWeaponDrawn && Service.ClientState.LocalPlayer != null && Service.ClientState.LocalPlayer.StatusFlags.HasFlag(StatusFlags.WeaponOut)) {
+            requestToBeShown = true;
+        } else {
+            requestToHide = true;
+        }
+
+        if (!targetCircleShown && requestToBeShown) {
+            Service.GameConfig.UiControl.Set("ObjectBorderingType", 1);
+        } else if (targetCircleShown && requestToHide) {
+            Service.GameConfig.UiControl.Set("ObjectBorderingType", 0);
+        }
+    }
+
+    public class Configs : TweakConfig {
+        [TweakConfigOption("Out of Combat Time (Seconds)", 3, EditorSize = 100, IntMin = 0, IntMax = 300, ConditionalDisplay = true)]
+        public int CombatBuffer = 3;
+
+        [TweakConfigOption("Show In Combat", 2)]
+        public bool ShowInCombat = true;
+
+        [TweakConfigOption("Show In Duty", 1)] 
+        public bool ShowInDuty = true;
+
+        [TweakConfigOption("Show While Weapon Is Drawn", 4)]
+        public bool ShowWhileWeaponDrawn;
+
+        public bool ShouldShowCombatBuffer() => ShowInCombat;
+    }
+}

--- a/strings.json
+++ b/strings.json
@@ -1339,6 +1339,14 @@
     "message": "Hide Target Circle",
     "description": "[HideTargetCircle] Tweak Name"
   },
+  "UiAdjustments@HideTargetHighlight / Description": {
+    "message": "Allow hiding the potential target outline while not in combat or dungeons.",
+    "description": "[HideTargetHighlight] Tweak Description"
+  },
+  "UiAdjustments@HideTargetHighlight / Name": {
+    "message": "Hide Target Hightlight/Outline",
+    "description": "[HideTargetHighlight] Tweak Name"
+  },
   "UiAdjustments@HideUnwantedBanner / Description": {
     "message": "Hide information banners such as 'Venture Complete', or 'Levequest Accepted'",
     "description": "[HideUnwantedBanner] Tweak Description"


### PR DESCRIPTION
This tweak is essentially the same as the existing [HideTargetCircle] by darkarchon but is applied to "Highlight potential targets" option in the Target Display settings.
![ui_target](https://github.com/user-attachments/assets/f17e9bec-05c2-4da1-9067-4fc19a190935)

