### PR TITLE
Remove /playerplate invalid target error message

### DIFF
--- a/Tweaks/CharaCardCommand.cs
+++ b/Tweaks/CharaCardCommand.cs
@@ -33,8 +33,6 @@ public unsafe class CharaCardCommand : CommandTweak {
 
         if (resolve != null && resolve->ObjectKind == ObjectKind.Pc && resolve->SubKind == 4) {
             AgentCharaCard.Instance()->OpenCharaCard(resolve);
-        } else {
-            Service.Chat.PrintError($"{arguments} is not a player.");
         }
     }
 }


### PR DESCRIPTION
When using the `/playerplate` command in a macro to view the adventurer plate of either a target or mouseover target like so:
```
/playerplate <t>
/playerplate <mo>
```
the macro would always output a error for the placeholder that didn't resolve even when the other placeholder does resolve. It's also not possible to filter out these error messages using the game's built-in log filters.

This change remove the error message when a placeholder fails to resolve, which is consistent with the game's built-in `/check` (examine) command.