### PR TITLE
fix: Redirect new assemblies for tweaks

### DIFF
--- a/TweakSystem/TweakLoadContext.cs
+++ b/TweakSystem/TweakLoadContext.cs
@@ -25,7 +25,12 @@ public class TweakLoadContext : AssemblyLoadContext {
         handledAssemblies = new Dictionary<string, Assembly>() {
             ["SimpleTweaksPlugin"] = typeof(SimpleTweaksPlugin).Assembly,
             ["FFXIVClientStructs"] = typeof(FFXIVClientStructs.ThisAssembly).Assembly,
+            ["InteropGenerator.Runtime"] = typeof(InteropGenerator.Runtime.CStringPointer).Assembly,
             ["Dalamud"] = typeof(IDalamudPluginInterface).Assembly,
+            ["Dalamud.Bindings.ImGui"] = typeof(Dalamud.Bindings.ImGui.ImGui).Assembly,
+            ["Dalamud.Bindings.ImPlot"] = typeof(Dalamud.Bindings.ImPlot.ImPlot).Assembly,
+            ["Lumina"] = typeof(Lumina.GameData).Assembly,
+            ["Lumina.Excel"] = typeof(Lumina.Excel.Sheets.Achievement).Assembly,
         };
     }
     


### PR DESCRIPTION
Fixes tweak loading with new imgui and interop:

<img width="702" height="423" alt="image" src="https://github.com/user-attachments/assets/6f1ef0fa-98a8-4e4c-b36a-ce59c248c452" />
