### PR TITLE
`ShowItemID` Safer node lookup

### DIFF
--- a/Tweaks/Tooltips/ShowItemID.cs
+++ b/Tweaks/Tooltips/ShowItemID.cs
@@ -75,8 +75,7 @@ public unsafe class ShowItemID : TooltipTweaks.SubTweak {
     }
 
     public override void OnActionTooltip(AtkUnitBase* addon, TooltipTweaks.HoveredActionDetail action) {
-        if (addon->UldManager.NodeList == null || addon->UldManager.NodeListCount < 29) return;
-        var categoryText = (AtkTextNode*)addon->UldManager.NodeList[28];
+        var categoryText = addon->GetTextNodeById(6);
         if (categoryText == null) return;
         var seStr = Common.ReadSeString(categoryText->NodeText.StringPtr);
         if (seStr.Payloads.Count > 1) return;


### PR DESCRIPTION
Uses GetTextNodeById instead of directly accessing the node by index.

If you instead want to keep the old approach, then additional type checking is required or a CTD is caused by trying to read a null StringPtr when the tooltip is modified by other plugins or has nodes added.