### PR TITLE
More node safety

### DIFF
--- a/Tweaks/UiAdjustment/CastBarAdjustments.cs
+++ b/Tweaks/UiAdjustment/CastBarAdjustments.cs
@@ -137,14 +137,14 @@ public unsafe class CastBarAdjustments : UiAdjustments.SubTweak {
 
         if (castBar->AtkUnitBase.UldManager.NodeList == null || castBar->AtkUnitBase.UldManager.NodeListCount < 12) return;
 
-        var barNode = castBar->AtkUnitBase.UldManager.NodeList[3];
+        var barNode = castBar->GetNodeById(9);
 
-        var icon = (AtkComponentNode*)castBar->AtkUnitBase.GetNodeById(8);
-        var countdownText = castBar->AtkUnitBase.GetTextNodeById(7);
-        var castingText = castBar->AtkUnitBase.GetTextNodeById(6);
-        var skillNameText = castBar->AtkUnitBase.GetTextNodeById(4);
-        var progressBar = (AtkNineGridNode*)castBar->AtkUnitBase.GetNodeById(11);
-        var interruptedText = castBar->AtkUnitBase.GetTextNodeById(2);
+        var icon = castBar->GetComponentNodeById(8);
+        var countdownText = castBar->GetTextNodeById(7);
+        var castingText = castBar->GetTextNodeById(6);
+        var skillNameText = castBar->GetTextNodeById(4);
+        var progressBar = (AtkNineGridNode*)castBar->GetNodeById(11);
+        var interruptedText = castBar->GetTextNodeById(2);
         var slideMarker = (AtkNineGridNode*)null;
         var classicSlideMarker = (AtkImageNode*)null;
 

--- a/Tweaks/UiAdjustment/MinimapAdjustments.cs
+++ b/Tweaks/UiAdjustment/MinimapAdjustments.cs
@@ -117,11 +117,11 @@ public unsafe class MinimapAdjustments : UiAdjustments.SubTweak {
 
         if (unitBase->UldManager.NodeListCount < 19) return;
 
-        var sunImage = unitBase->UldManager.NodeList[4];
+        var sunImage = unitBase->GetImageNodeById(16);
         if (enabled && Config.HideSun) sunImage->ToggleVisibility(false);
         else sunImage->ToggleVisibility(true);
 
-        var weatherIcon = unitBase->UldManager.NodeList[6];
+        var weatherIcon = unitBase->GetComponentNodeById(14);
         if (enabled && Config.HideWeather) weatherIcon->ToggleVisibility(false);
         else weatherIcon->ToggleVisibility(true);
 
@@ -135,21 +135,21 @@ public unsafe class MinimapAdjustments : UiAdjustments.SubTweak {
             UiHelper.SetPosition(weatherIcon, 158, 24);
         }
 
-        var standardBorderImage = unitBase->UldManager.NodeList[5];
+        var standardBorderImage = unitBase->GetImageNodeById(15);
         if (enabled && Config.CleanBorder && Config.NoBorder) standardBorderImage->ToggleVisibility(false);
         else standardBorderImage->ToggleVisibility(true);
 
-        var fancyBorderImage = unitBase->UldManager.NodeList[8];
+        var fancyBorderImage = unitBase->GetImageNodeById(13);
         if (enabled && Config.CleanBorder) fancyBorderImage->ToggleVisibility(false);
         else fancyBorderImage->ToggleVisibility(true);
 
-        for (var i = 9; i < 13; i++) {
-            var directionIcon = unitBase->UldManager.NodeList[i];
+        for (uint i = 9; i < 13; i++) {
+            var directionIcon = unitBase->GetImageNodeById(i);
             if (enabled && Config.HideCompassDirections) directionIcon->ToggleVisibility(false);
             else directionIcon->ToggleVisibility(true);
         }
 
-        var coordinateDisplay = unitBase->UldManager.NodeList[13];
+        var coordinateDisplay = unitBase->GetNodeById(5);
         if (enabled && Config.HideCoordinates) coordinateDisplay->ToggleVisibility(false);
         else coordinateDisplay->ToggleVisibility(true);
         if (enabled) {
@@ -158,12 +158,12 @@ public unsafe class MinimapAdjustments : UiAdjustments.SubTweak {
             coordinateDisplay->SetPositionFloat(44, 194);
         }
 
-        var compassLockButton = unitBase->UldManager.NodeList[16];
+        var compassLockButton = unitBase->GetComponentNodeById(4);
         if (enabled && Config.HideCompassLock) compassLockButton->ToggleVisibility(false);
         else compassLockButton->ToggleVisibility(true);
 
-        for (var i = 17; i < 19; i++) {
-            var zoomButton = unitBase->UldManager.NodeList[i];
+        for (uint i = 2; i < 4; i++) {
+            var zoomButton = unitBase->GetComponentNodeById(i);
             if (enabled && Config.HideZoom) zoomButton->ToggleVisibility(false);
             else zoomButton->ToggleVisibility(true);
         }

--- a/Tweaks/UiAdjustment/NotificationToastAdjustments.cs
+++ b/Tweaks/UiAdjustment/NotificationToastAdjustments.cs
@@ -145,7 +145,7 @@ namespace SimpleTweaksPlugin.Tweaks.UiAdjustment {
             if (toastUnitBase == null) return null;
             if (toastUnitBase->UldManager.NodeList == null || toastUnitBase->UldManager.NodeListCount < 4) return null;
 
-            return toastUnitBase->UldManager.NodeList[0];
+            return toastUnitBase->RootNode;
         }
 
         private static void SetOffsetPosition(AtkResNode* node, float offsetX, float offsetY, float scale) {

--- a/Tweaks/UiAdjustment/ReducedDeepDungeonInfo.cs
+++ b/Tweaks/UiAdjustment/ReducedDeepDungeonInfo.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Dalamud.Game.Text.SeStringHandling;
@@ -40,13 +39,10 @@ public unsafe class ReducedDeepDungeonInfo : UiAdjustments.SubTweak {
     private void UpdateDeepDungeonStatus(AtkUnitBase* deepDungeonUnitBase, bool reset) {
         if (deepDungeonUnitBase == null) return;
         
-        if (deepDungeonUnitBase->UldManager.NodeList == null ||
-            deepDungeonUnitBase->UldManager.NodeListCount < 84) return;
-
-        var resNode = deepDungeonUnitBase->UldManager.NodeList[0];
-        var guideNode = deepDungeonUnitBase->UldManager.SearchNodeById(3);
-        var windowCollisionNode = (AtkCollisionNode*) deepDungeonUnitBase->UldManager.NodeList[1];
-        var windowNode = (AtkComponentNode*) deepDungeonUnitBase->UldManager.NodeList[4];
+        var resNode = deepDungeonUnitBase->RootNode;
+        var guideNode = deepDungeonUnitBase->GetNodeById(3);
+        var windowCollisionNode = deepDungeonUnitBase->WindowCollisionNode;
+        var windowNode = deepDungeonUnitBase->WindowNode;
         var itemsEffectsInfoNode = deepDungeonUnitBase->GetNodeById(64);
         var magiciteInfoNode = deepDungeonUnitBase->GetNodeById(54);
         var itemsInfoNode = deepDungeonUnitBase->GetNodeById(16);
@@ -155,9 +151,9 @@ public unsafe class ReducedDeepDungeonInfo : UiAdjustments.SubTweak {
 
         foreach (var payload in aetherpoolSeStr.Payloads.Where(p => p.Type == PayloadType.RawText)) {
             var text = ((TextPayload)payload).Text;
-            if (text.IndexOf('+') != -1)
+            if (text?.IndexOf('+') != -1)
             {
-                aetherpool = text.Substring(text.IndexOf('+'));
+                aetherpool = text?[text.IndexOf('+')..];
                 break;
             }
         }


### PR DESCRIPTION
The only tweaks remaining that are still accessing nodes directly are:

BuffListVerticalGrowth
LimitTargetStatusEffects

These I was not comfortable modifying. I will keep them in mind if I consider making any features that could conflict with them.

All others are either debug/uidebug functions, are carefully check the nodeid/type of node returned from direct acces, or are iterating over all nodes anyways.
