### PR TITLE
Update signature for AgentItemSearchUpdateAtkValuesHook in FastSearch

### DIFF
--- a/Tweaks/UiAdjustment/FastSearch.cs
+++ b/Tweaks/UiAdjustment/FastSearch.cs
@@ -57,7 +57,7 @@ public unsafe class FastSearch : UiAdjustments.SubTweak {
 
     private delegate void AgentItemSearchUpdateAtkValuesDelegate(AgentItemSearch* a1, uint a2, byte* a3, bool a4);
 
-    [TweakHook, Signature("40 55 56 41 56 B8", DetourName = nameof(AgentItemSearchUpdateAtkValuesDetour))]
+    [TweakHook, Signature("E9 ?? ?? ?? ?? E5 96", DetourName = nameof(AgentItemSearchUpdateAtkValuesDetour))]
     private readonly HookWrapper<AgentItemSearchUpdateAtkValuesDelegate> agentItemSearchUpdateAtkValuesHook;
 
     private delegate void AgentItemSearchPushFoundItemsDelegate(AgentItemSearch* a1);


### PR DESCRIPTION
Current signature has multiple hits 
<img width="588" height="108" alt="image" src="https://github.com/user-attachments/assets/8d739357-da70-43ca-9a54-669413fcf75c" />

New sig has a better hit for the function 
<img width="484" height="77" alt="image" src="https://github.com/user-attachments/assets/e3539cb2-ae85-4552-a913-90964f0ce655" />
