### PR TITLE
`TrackOutfits` HQ fix

### DIFF
--- a/Tweaks/Tooltips/TrackOutfits.cs
+++ b/Tweaks/Tooltips/TrackOutfits.cs
@@ -15,6 +15,7 @@ namespace SimpleTweaksPlugin.Tweaks.Tooltips;
 [TweakDescription("Shows whether or not you've made an outfit out of the hovered item.")]
 [TweakAuthor("croizat")]
 [TweakReleaseVersion("1.10.8.0")]
+[Changelog(UnreleasedVersion, "Fixed HQ outfits not working.")]
 public unsafe class TrackOutfits : TooltipTweaks.SubTweak
 {
     [TweakHook(typeof(UIState), nameof(UIState.IsItemActionUnlocked), nameof(IsItemActionUnlockedDetour))]


### PR DESCRIPTION
item id checks compare against base now since I forgot at the time HQ outfits were a thing