### PR TITLE
Add Auto Level Sync tweak for Fates

### DIFF
--- a/Tweaks/UiAdjustment/AutoLevelSync.cs
+++ b/Tweaks/UiAdjustment/AutoLevelSync.cs
@@ -1,0 +1,63 @@
+using System;
+using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.Game.Fate;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using SimpleTweaksPlugin.TweakSystem;
+using SimpleTweaksPlugin.Utility;
+
+namespace SimpleTweaksPlugin.Tweaks;
+
+[TweakName("Auto Level Sync")]
+[TweakDescription("Automaticaly sync your level during fates when needed.")]
+[TweakAuthor("Bryer")]
+[TweakCategory(TweakCategory.QoL)]
+public unsafe class AutoLevelSync : Tweak
+{
+    private bool wasInFate;
+
+    protected override void Enable()
+    {
+        Service.Framework.Update += OnUpdate;
+    }
+
+    protected override void Disable()
+    {
+        Service.Framework.Update -= OnUpdate;
+    }
+
+    private void OnUpdate(IFramework framework)
+    {
+        try
+        {
+            var fateManager = FateManager.Instance();
+            if (fateManager == null)
+                return;
+
+            var fate = fateManager->CurrentFate;
+            bool inFate = fate != null;
+
+            if (inFate && !wasInFate)
+            {
+                TrySync();
+            }
+
+            wasInFate = inFate;
+        }
+        catch (Exception ex)
+        {
+            SimpleLog.Error(ex, "AutoLevelSync error");
+        }
+    }
+
+private void TrySync()
+{
+    try
+    {
+        ChatHelper.SendMessage("/levelsync");
+    }
+    catch (Exception ex)
+    {
+        SimpleLog.Error(ex, "AutoLevelSync TrySync error");
+    }
+}
+}


### PR DESCRIPTION
Pretty simple and straight forward tweak. If enabled, it detects when the player is in a Fate that requires `Level Sync` enabled to join and automaticaly do so, removing
the need to manually press the **"Level Sync"** button. Thats it.

- Matches SimpleTweaks UI style on the window `Simple Tweaks Config`
- The tweak can  be found on the tabs `All Tweaks` and `QoL`

When enabled, it hooks into the game update loop `Service.Framework.Update += OnUpdate;`, it runs every frame and checks if the player is inside a FATE.

To ensures the action only triggers when entering a FATE, I used:
``` csharp
if (inFate && !wasInFate)
{
    TrySync();
}
```
To trigger the Level Sync the tweak uses the in-game command `/levelsync` without actualy sending it in chat as a message.

I tested it myself for about 4 hours farming fates below my level and also got a friend to test it during that time. Everything runs smooth and fine.

> Having it enabled even when not doing Fates doesnt affect anything at all.

Author: Bryer