### PR TITLE
Increase perceived brightness of random chat name colors

### DIFF
--- a/Tweaks/Chat/ChatNameColours.cs
+++ b/Tweaks/Chat/ChatNameColours.cs
@@ -85,7 +85,7 @@ public class ChatNameColours : ChatTweaks.SubTweak {
         var key = $"{playerName}@{worldName}".GetStableHashCode();
         var hue = new Random(key).NextSingle();
         var c = new Vector3();
-        ImGui.ColorConvertHSVtoRGB(hue, 1, 1, ref c.X, ref c.Y, ref c.Z);
+        ImGui.ColorConvertHSVtoRGB(hue, 0.6f, 1, ref c.X, ref c.Y, ref c.Z);
         return c;
     }
 


### PR DESCRIPTION
Small change. Reduces the saturation of the randomly generated chat name colors to increase perceived brightness. HSV isn't a very even color space, so in the blue hue especially, at full saturation, colors will be very dark. On the other hand, they're very light around the yellow hue for example. Reducing the saturation component balances this out, while still keeping things colorful. I've been running this change for a couple months now and am very happy with it.