### PR TITLE
Disable DisableNoviceNetworkAutoSwitch

### DIFF
--- a/tweakBlacklist.txt
+++ b/tweakBlacklist.txt
@@ -6,3 +6,4 @@ UiAdjustments@FadeUnavailableActions
 UiAdjustments@LockWindowPosition
 UiAdjustments@SubmarineDestinationLetters
 CharaCardCommand
+DisableNoviceNetworkAutoSwitch


### PR DESCRIPTION
Crashing people if the hook fails due to no try catch and/or no null check (which will be the case with a CS breaking change).