### PR TITLE
Use AddonPreShow event for HideAchievementsNotifications

### DIFF
--- a/Events/AddonEventAttribute.cs
+++ b/Events/AddonEventAttribute.cs
@@ -77,4 +77,37 @@ public class AddonPostReceiveEventAttribute : AddonEventAttribute {
     public AddonPostReceiveEventAttribute(params string[] addonNames) : base(AddonEvent.PostReceiveEvent, addonNames) { }
 }
 
+public class AddonPreOpenAttribute : AddonEventAttribute {
+    public AddonPreOpenAttribute(params string[] addonNames) : base(AddonEvent.PreOpen, addonNames) { }
+}
+
+public class AddonPostOpenAttribute : AddonEventAttribute {
+    public AddonPostOpenAttribute(params string[] addonNames) : base(AddonEvent.PostOpen, addonNames) { }
+}
+
+public class AddonPreCloseAttribute : AddonEventAttribute {
+    public AddonPreCloseAttribute(params string[] addonNames) : base(AddonEvent.PreClose, addonNames) { }
+}
+
+public class AddonPostCloseAttribute : AddonEventAttribute {
+    public AddonPostCloseAttribute(params string[] addonNames) : base(AddonEvent.PostClose, addonNames) { }
+}
+
+public class AddonPreShowAttribute : AddonEventAttribute {
+    public AddonPreShowAttribute(params string[] addonNames) : base(AddonEvent.PreShow, addonNames) { }
+}
+
+public class AddonPostShowAttribute : AddonEventAttribute {
+    public AddonPostShowAttribute(params string[] addonNames) : base(AddonEvent.PostShow, addonNames) { }
+}
+
+public class AddonPreHideAttribute : AddonEventAttribute {
+    public AddonPreHideAttribute(params string[] addonNames) : base(AddonEvent.PreHide, addonNames) { }
+}
+
+public class AddonPostHideAttribute : AddonEventAttribute {
+    public AddonPostHideAttribute(params string[] addonNames) : base(AddonEvent.PostHide, addonNames) { }
+}
+
+
 #endregion

--- a/Tweaks/UiAdjustment/HideAchievementsNotifications.cs
+++ b/Tweaks/UiAdjustment/HideAchievementsNotifications.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using Dalamud.Game.Config;
 using Dalamud.Interface.Colors;
-using Dalamud.Bindings.ImGui;
 using SimpleTweaksPlugin.Events;
 using SimpleTweaksPlugin.TweakSystem;
-using SimpleTweaksPlugin.Utility;
 
 namespace SimpleTweaksPlugin.Tweaks.UiAdjustment;
 
@@ -41,19 +40,13 @@ public class HideAchievementsNotifications : UiAdjustments.SubTweak {
         hasChanged |= ImGui.Checkbox(LocString("HideZoneIn", "Hide the zone-in notification."), ref Config.HideZoneIn);
     }
 
-    [FrameworkUpdate(NthTick = 10)]
-    private void HideNotifications() {
-        if (Config.HideLogIn) HideNotification("_NotificationAchieveLogIn");
-        if (Config.HideZoneIn) HideNotification("_NotificationAchieveZoneIn");
-    }
-
-    private unsafe void HideNotification(string name) {
-        try {
-            var atkUnitBase = Common.GetUnitBase(name);
-            if (atkUnitBase == null || atkUnitBase->IsVisible == false) return;
-            atkUnitBase->Hide(false, false, 1);
-        } catch (Exception) {
-            // ignore
+    [AddonPreShow("_NotificationAchieveLogIn", "_NotificationAchieveZoneIn")]
+    private void HideNotification(AddonArgs args) {
+        switch (args.AddonName) {
+            case "_NotificationAchieveLogIn" when Config.HideLogIn:
+            case "_NotificationAchieveZoneIn" when Config.HideZoneIn:
+                args.PreventOriginal();
+                break;
         }
     }
 }


### PR DESCRIPTION
I noticed that the notifications were still shown for a split second on login, so I reworked it to use the AddonLifecycle PreShow event to prevent it from being shown at all.

Had to add `AddonPreOpenAttribute` for that, and thought I'd add some more commonly used ones while I'm at it.